### PR TITLE
Redundant Words removed

### DIFF
--- a/modules/ROOT/pages/subdocument-operations.adoc
+++ b/modules/ROOT/pages/subdocument-operations.adoc
@@ -210,7 +210,7 @@ bucket
   });
 ----
 
-If you wish to create an array if it does not exist and also push elements to it within the same operation you may use the _create-parents_ option:
+If you wish to create an array that does not exist and also push elements to it within the same operation you may use the _create-parents_ option:
 
 [source,javascript]
 ----


### PR DESCRIPTION
Line 213- "If you wish to create an array if it does not exist and also push elements to it within the same operation you may use the _create-parents_ option:"
updated to "If you wish to create an array that does not exist and also push elements to it within the same operation you may use the _create-parents_ option:"
as if it was redundant and "that" should be used to refer to the array.