### PR TITLE
Doc error

### DIFF
--- a/modules/ROOT/pages/subdocument-operations.adoc
+++ b/modules/ROOT/pages/subdocument-operations.adoc
@@ -51,7 +51,7 @@ Considering the document:
 }
 ----
 
-The paths `name`, `addresses.billing.country` and `purchases.complete[0]` are all valid paths.
+The path's `name`, `addresses.billing.country` and `purchases.complete[0]` are all valid paths.
 
 == Retrieving
 


### PR DESCRIPTION
Line 54 - Updated "The paths name, addresses.billing.country and purchases.complete[0] are all valid paths."
to "The path's name, addresses.billing.country and purchases.complete[0] are all valid paths."
as we are referring to name, addresses.billing.country of the specific path. So apostrophe.