### PR TITLE
Update subdocument-operations.adoc

### DIFF
--- a/modules/ROOT/pages/subdocument-operations.adoc
+++ b/modules/ROOT/pages/subdocument-operations.adoc
@@ -460,7 +460,7 @@ Considering the document
 
 A path such as 
  \`literal[]bracket`.\`literal.dot`.
-You can use double-backticks (pass:c[``]) to reference a literal backtick.
+You can use double-backticks (pass:c[``]) for reference to a literal backtick.
 
 If you need to combine both JSON _and_ path-syntax literals you can do so by escaping the component from any JSON string characters
 (e.g. a quote or backslash) and then encapsulating it in backticks (`pass:c[`path`]`):


### PR DESCRIPTION
Line 463 - "A path such as `literal[]bracket`.`literal.dot`. You can use double-backticks (``) to reference a literal backtick."
updated to "A path such as `literal[]bracket`.`literal.dot`. You can use double-backticks (``) for reference to a literal backtick."
as "for" should be used for referring to something.