### PR TITLE
DOC-6252 - provide annotated source code for use in documentation

### DIFF
--- a/modules/devguide/examples/nodejs/bulkES6.js
+++ b/modules/devguide/examples/nodejs/bulkES6.js
@@ -1,0 +1,273 @@
+// This is a Couchbase bulk api example written using ES6 features.  This
+//  example creates a group of documents, and then retrives them using the
+//  "getMulti" method to load them all into the node application memory.  It
+//  also shows an asyncronous pattern for retrieving documents, and then shows
+//  an example of how this might be used for bulk processing to update documents
+//  in bulk.
+//
+// Please ensure the version of nodejs installed in your environment is using
+//  at least version 4.0.0 prior to running this example.
+//
+//
+// TO RUN:
+//  [1] Include package.json file below
+//  [2] npm install
+//  [3] Change the Couchbase "Connection string" to match your cluster
+//  [4] node app.js OR npm start
+//  [5] Edit these fields to change the characteristics of what this example does:
+//    -- connString: The connection string to your cluster
+//    -- opsGroup: This is the "buffer" of operations to keep in the queue for
+//        creating new documents.
+//    -- totalDocs: Number of new documents to create/and then bulk retrieve
+//    -- documentSize: Controls how big of a field (in chracters) the "fieldToProcess"
+//        field is for each document created.
+//
+//  package.json File, save and include separately
+/*
+{
+  "name": "nodejs",
+  "version": "1.0.0",
+  "description": "Test Application Codebook",
+  "main": "bulk.js",
+  "scripts": {
+       "start": "node bulk.js"
+  },
+  "author": "todd@couchbase.com",
+  "license": "ISC",
+  "dependencies": {
+    "couchbase": "^2.2.3"
+  }
+}
+*/
+
+'use strict';
+
+// Key for example
+var connString='couchbase://localhost';
+var opsGroup=1000;
+var totalDocs=10000;
+var documentSize=2048;
+var getMultiArray=[];
+
+// Require Couchbase Module
+var couchbase = require('couchbase');
+
+// Setup Cluster Connection Object
+var cluster = new couchbase.Cluster(connString);
+
+// Setup Bucket object to be reused within the code
+var bucket = cluster.openBucket('travel-sample');
+
+// Run the example
+verifyNodejsVersion()
+    .then(preload)
+    .then(bulkGetMulti)
+    .then(bulkGetAsyncPattern)
+    .then(bulkUpdateAsyncPattern)
+    .then(() => {
+        process.exit(0);
+    })
+    .catch((err) => {
+        console.log("ERR:", err)
+        process.exit(0);
+    });
+
+function verifyNodejsVersion() {
+    return new Promise(
+        (resolve, reject) => {
+            if (parseInt(((process.version).split("v"))[1].substr(0, 1)) < 4) {
+                console.log("\n  The nodejs version is too low.  This application requires\n" +
+                    "  ES6 features, specifically: \n" +
+                    "    --promises \n    --arrow functions \n" +
+                    "  Please upgrade the nodejs version from:\n    --Current " +
+                    process.version + "\n    --Minimum:4.0.0");
+                reject();
+            } else resolve();
+        });
+}
+
+function preload() {
+    return new Promise(
+        (resolve, reject) => {
+
+            var completed = 0;
+            var runFlag = false;
+            var startTime = process.hrtime();
+
+            // Function for upserting one document, during preload.  Notice,
+            // this is only in scope for preload
+            function upsertOne() {
+
+                // First Check if the preloading is done
+                if (completed >= totalDocs && !runFlag) {
+                    runFlag = true;
+                    var time = process.hrtime(startTime);
+                    console.log("====");
+                    console.log("  Async Insert Loop Took: " + parseInt((time[0] * 1000) +
+                            (time[1] / 1000000)) + " ms for: " + getMultiArray.length +
+                        " items");
+                    resolve();
+                } else {
+                    if (completed <= totalDocs) {
+
+                        // Add key to array for later bulk retrieval
+                        getMultiArray[completed] = 'test' + completed;
+
+                        // Upsert one document
+                        bucket.upsert('test' + completed, {
+                            fieldToProcess: generateCharacters(documentSize),
+                            fieldType: "url",
+                            lastEdited: Date(),
+                            rev: 0
+                        }, function(err, res) {
+                            if (err) reject(err);
+
+                            // This will fire WHEN and only WHEN a callback is received.
+                            if (res) {
+                                // Increment completed upserts count
+                                completed++;
+
+                                // Recursive call to insert
+                                upsertOne();
+                            }
+                        });
+                    }
+                }
+            }
+            // The loop that sets up a "buffer" of queued operations
+            // This sets up a number of requests always in the buffer waiting to execute
+            for (var i = 0; i < opsGroup; ++i) {
+                upsertOne();
+            }
+        });
+}
+
+function bulkGetMulti() {
+    return new Promise((resolve, reject) => {
+        var startTime = process.hrtime();
+
+        // This is the only bulk method exposed by the nodejs SDK.   This method
+        // takes an array of keys, and returns a map of json documents for all
+        // documents retrieved.   It will fire a callback when completed.
+        bucket.getMulti(getMultiArray, function(err, res) {
+            if (err) {
+                console.console.log("  Error:", error);
+            }
+            // The callback "res" will only fire once the getMulti
+            // operation has finished
+            if (res) {
+                var time = process.hrtime(startTime);
+                console.log("====");
+                console.log("  Bulk getMulti took: " + parseInt((time[0] * 1000) +
+                        (time[1] / 1000000)) + " ms for: " + getMultiArray.length +
+                    " items");
+                resolve();
+            }
+        });
+    });
+}
+
+function bulkGetAsyncPattern(){
+  return new Promise(
+      (resolve, reject) => {
+
+          var completed = 0;
+          var runFlag = false;
+          var startTime = process.hrtime();
+
+          // Function for modify one document, during bulk loop.  Notice,
+          // this is only in scope for bulkGetAsyncPattern
+          function getOne() {
+
+              // First Check if the bulk pattern loop is done
+              if (completed >= totalDocs && !runFlag) {
+                  runFlag = true;
+                  var time = process.hrtime(startTime);
+                  console.log("====");
+                  console.log("  Bulk Pattern Get Loop Took: " + parseInt((time[0] * 1000) +
+                          (time[1] / 1000000)) + " ms for: " + getMultiArray.length +
+                      " items");
+                  resolve();
+              } else {
+                  if (completed <= totalDocs) {
+
+                      // Modify One Document
+                      bucket.get(getMultiArray[completed], function(err, res) {
+                          if (err) console.log("  Error Retrieving:", err.message);
+
+                          // This will fire WHEN and only WHEN a callback is received.
+                          if (res) {
+                              // Increment completed count
+                              completed++;
+
+                              // Recursive call to modify
+                              getOne();
+                          }
+                      });
+                  }
+              }
+          }
+          // The loop that sets up a "buffer" of queued operations
+          // This sets up a number of requests always in the buffer waiting to execute
+          for (var i = 0; i < opsGroup; ++i) {
+              getOne();
+          }
+      });
+}
+
+function bulkUpdateAsyncPattern(){
+  return new Promise(
+      (resolve, reject) => {
+
+          var completed = 0;
+          var runFlag = false;
+          var startTime = process.hrtime();
+
+          // Function for modify one document, during bulk loop.  Notice,
+          // this is only in scope for bulkUpdateAsyncPattern
+          function modifyOne() {
+
+              // First Check if the bulk pattern loop is done
+              if (completed >= totalDocs && !runFlag) {
+                  runFlag = true;
+                  var time = process.hrtime(startTime);
+                  console.log("====");
+                  console.log("  Bulk Pattern Processing Loop Took: " + parseInt((time[0] * 1000) +
+                          (time[1] / 1000000)) + " ms for: " + getMultiArray.length +
+                      " items");
+                  resolve();
+              } else {
+                  if (completed <= totalDocs) {
+
+                      // Modify One Document
+                      bucket.mutateIn('test' + completed, 0, 0)
+                      .counter('rev', 1, false)
+                      .execute( function(err, res) {
+                          if (err) console.log("  Error modifying:", err.message);
+
+                          // This will fire WHEN and only WHEN a callback is received.
+                          if (res) {
+                              // Increment completed count
+                              completed++;
+
+                              // Recursive call to modify
+                              modifyOne();
+                          }
+                      });
+                  }
+              }
+          }
+          // The loop that sets up a "buffer" of queued operations
+          // This sets up a number of requests always in the buffer waiting to execute
+          for (var i = 0; i < opsGroup; ++i) {
+              modifyOne();
+          }
+      });
+}
+
+// Generate Random Characters to document field size
+function generateCharacters(len) {
+    var rdmString = "";
+    for (; rdmString.length < len; rdmString += Math.random().toString(36).substr(2));
+    return rdmString.substr(0, len);
+}

--- a/modules/devguide/examples/nodejs/connecting-cert-auth.js
+++ b/modules/devguide/examples/nodejs/connecting-cert-auth.js
@@ -1,0 +1,18 @@
+// Require Couchbase Module
+var couchbase = require('couchbase');
+
+// Setup Cluster Connection Object
+var cluster = new couchbase.Cluster(
+    'couchbases://127.0.0.1/' +
+    '?truststorepath=../etc/x509-cert/SSLCA/clientdir/trust.pem' +
+    '&certpath=../etc/x509-cert/SSLCA/clientdir/client.pem' +
+    '&keypath=../etc/x509-cert/SSLCA/clientdir/client.key');
+
+// Authenticate with the cluster
+cluster.authenticate(new couchbase.CertAuthenticator());
+
+// Setup Bucket object to be reused within the code
+var bucket = cluster.openBucket('travel-sample');
+
+console.log('Example Successful - Exiting');
+process.exit(0);

--- a/modules/devguide/examples/nodejs/connecting-ssl.js
+++ b/modules/devguide/examples/nodejs/connecting-ssl.js
@@ -1,0 +1,21 @@
+// Require Couchbase Module
+var couchbase = require('couchbase');
+
+/*
+ * Put Self-Signed Cluster Certificate from the cluster
+ * to /tmp/couchbase-ssl-certificate.pem:
+ *
+ * $ curl http://localhost:8091/pools/default/certificate > /tmp/couchbase-ssl-certificate.pem
+ */
+
+// Setup Cluster Connection Object
+var cluster = new couchbase.Cluster('couchbase://127.0.0.1?certpath=/tmp/couchbase-ssl-certificate.pem');
+
+// Authenticate with the cluster
+cluster.authenticate('Administrator', 'password');
+
+// Setup Bucket object to be reused within the code
+var bucket = cluster.openBucket('travel-sample');
+
+console.log('Example Successful - Exiting');
+process.exit(0);

--- a/modules/devguide/examples/nodejs/connecting.js
+++ b/modules/devguide/examples/nodejs/connecting.js
@@ -1,0 +1,14 @@
+// Require Couchbase Module
+var couchbase = require('couchbase');
+
+// Setup Cluster Connection Object
+var cluster = new couchbase.Cluster('couchbase://127.0.0.1');
+
+// Authenticate with the cluster
+cluster.authenticate('Administrator', 'password');
+
+// Setup Bucket object to be reused within the code
+var bucket = cluster.openBucket('travel-sample');
+
+console.log('Example Successful - Exiting');
+process.exit(0);

--- a/modules/devguide/examples/nodejs/counter.js
+++ b/modules/devguide/examples/nodejs/counter.js
@@ -1,0 +1,25 @@
+// Require Couchbase Module
+var couchbase = require('couchbase');
+
+// Setup Cluster Connection Object
+var cluster = new couchbase.Cluster('couchbase://127.0.0.1');
+
+// Setup Bucket object to be reused within the code
+var bucket = cluster.openBucket('travel-sample');
+
+// Setup a new key, initialize as 10, add 2, and retreive it
+var key = "nodeDevguideExampleCounter";
+bucket.counter(key, 2, {initial: 10}, function(err, res) {
+  if (err) throw err;
+
+  console.log('Initialized Counter:', res.value);
+
+  bucket.counter(key, 2, {initial: 10}, function(err, res) {
+    if (err) throw err;
+
+    console.log('Incremented Counter:', res.value);
+
+    console.log('Example Successful - Exiting');
+    process.exit(0);
+  });
+});

--- a/modules/devguide/examples/nodejs/durability.js
+++ b/modules/devguide/examples/nodejs/durability.js
@@ -1,0 +1,115 @@
+// Require Couchbase Module
+var couchbase = require('couchbase');
+
+// Setup Cluster Connection Object
+var cluster = new couchbase.Cluster('couchbase://127.0.0.1');
+
+// Setup Bucket object to be reused within the code
+var bucket = cluster.openBucket('travel-sample');
+//bucket.durabilityTimeout=10;
+
+// Setup a Document and store in the bucket.
+var key = "nodeDevguideExampleDurability";
+
+persistExample(function(persistComplete){
+    if(persistComplete){
+        replicateExample(function(replicateComplete){
+            if(replicateComplete){
+                replicateAndPersistExample(function(replicateAndPersistComplete){
+                    if(replicateAndPersistComplete) {
+                        console.log('Example Successful - Exiting');
+                        process.exit(0);
+                    }
+                });
+            }
+        });
+    }
+});
+
+function persistExample(done) {
+
+    // Create a document and assign a "Persist To" value of 1 node.
+    // Should Always Succeed, even on single node cluster.
+    console.log("==========================================");
+    console.log("  BEGIN EXAMPLE: Persist To 1 node");
+    bucket.durabilityInterval=1000;
+    bucket.upsert(key, {test: "Some Test Value"}, {persist_to: 1}, function (err, res) {
+        if (err) throw err;
+
+        if (res) {
+            console.log("    CALLBACK: RESULT", res);
+            console.log("    Initialized Document, stored to bucket");
+
+            // Get Document
+            bucket.get(key, function (err, resRead) {
+                if (err) throw err;
+
+                // Print Document Value
+                console.log("    Retrieved Document:", resRead.value);
+                console.log("  END EXAMPLE");
+                console.log("==========================================");
+                done(true);
+            });
+        }
+    });
+}
+
+function replicateExample(done) {
+
+    // Create a document and assign a "Replicate To" value of 1 node.
+    // Should Fail on a single node cluster, succeed on a multi node
+    // cluster of 3 or more nodes with at least one replica enabled.
+    console.log("==========================================");
+    console.log("  BEGIN EXAMPLE: Replicate To 1 node");
+    bucket.durabilityInterval=1000;
+    bucket.upsert(key, {test: "Some Test Value"}, {replicate_to: 1}, function (err, res) {
+        if (err) throw err;
+
+        if (res) {
+            console.log("    CALLBACK: RESULT", res);
+            console.log("    Initialized Document, stored to bucket");
+
+            // Get Document
+            bucket.get(key, function (err, resRead) {
+                if (err) throw err;
+
+                // Print Document Value
+                console.log("    Retrieved Document:", resRead.value);
+                console.log("  END EXAMPLE");
+                console.log("==========================================");
+                done(true);
+            });
+        }
+    });
+}
+
+function replicateAndPersistExample(done) {
+
+    // Create a document and assign a "Replicate To" and a "Persist TO"
+    // value of 1 node. Should Fail on a single node cluster, succeed on
+    // a multi node cluster of 3 or more nodes with at least one replica
+    // enabled.
+    console.log("==========================================");
+    console.log("  BEGIN EXAMPLE: Replicate To and Persist To 1 node");
+    bucket.durabilityInterval=1000;
+    bucket.upsert(key, {test: "Some Test Value"}, {replicate_to: 1, persist_to:1}, function (err, res) {
+        if (err) throw err;
+
+        if (res) {
+            console.log("    CALLBACK: RESULT", res);
+            console.log("    Initialized Document, stored to bucket");
+
+            // Get Document
+            bucket.get(key, function (err, resRead) {
+                if (err) throw err;
+
+                // Print Document Value
+                console.log("    Retrieved Document:", resRead.value);
+                console.log("  END EXAMPLE");
+                console.log("==========================================");
+                done(true);
+            });
+        }
+    });
+}
+

--- a/modules/devguide/examples/nodejs/expiration.js
+++ b/modules/devguide/examples/nodejs/expiration.js
@@ -1,0 +1,43 @@
+// Require Couchbase Module
+var couchbase = require('couchbase');
+
+// Setup Cluster Connection Object
+var cluster = new couchbase.Cluster('couchbase://127.0.0.1');
+
+// Setup Bucket object to be reused within the code
+var bucket = cluster.openBucket('travel-sample');
+
+// Setup a new Document, with 2 second expiry and store in in the Bucket
+//		 - note -  API uses unix epoch time in seconds
+var key = "nodeDevguideExampleExpiry";
+bucket.insert(key, {test:"Some Test Value"}, {expiry: 2}, function(err, res) {
+    if (err) throw err;
+
+    if(res){
+
+        console.log('Initialized Document With Expiry');
+
+        // Get Document before Expiry
+        bucket.get(key, function(err, resPre) {
+            if (err) throw err;
+
+            if(resPre) {
+
+                console.log('Retreived Document Before Expiry:', resPre.value);
+
+                // Wait 4 seconds, and try to retrieve Document again
+                setTimeout(function () {
+                    bucket.get(key, function (err, resExp) {
+                        if (err){
+
+                            // Document expired, and should throw an error of not found
+                            console.log('Document Expired:', err.message)
+                            console.log('Example Successful - Exiting');
+                            process.exit(0);
+                        }
+                    });
+                }, 4000);
+            }
+        });
+    }
+});

--- a/modules/devguide/examples/nodejs/field-encryption.js
+++ b/modules/devguide/examples/nodejs/field-encryption.js
@@ -1,0 +1,57 @@
+'use strict';
+
+var couchbase = require('couchbase');
+var cbfieldcrypt = require('couchbase-encryption');
+
+var cluster = new couchbase.Cluster('couchbase://127.0.0.1');
+cluster.authenticate('Administrator', 'password');
+var bucket = cluster.openBucket('default');
+
+
+var publicKey = '!mysecretkey#9^5usdk39d&dlf)03sL';
+var signingKey = 'myauthpassword';
+
+var keyStore = new cbfieldcrypt.InsecureKeyStore();
+keyStore.addKey('publickey', publicKey);
+keyStore.addKey('mysecret', signingKey);
+
+var personCryptFields = {
+  password: new cbfieldcrypt.AesCryptoProvider(keyStore, 'publickey', 'mysecret')
+};
+
+// The Password field will be encrypted - see the definition of the
+// People object encrypted fields above.
+var teddy = {
+  age: 33,
+  firstName: 'Ted',
+  lastName: 'DeBloss',
+  password: 'ssloBeD12345'
+};
+
+//Password field will be encrypted in transport and at rest in the database
+var encryptedTeddy = cbfieldcrypt.encryptFields(teddy, personCryptFields);
+bucket.upsert('person::1', encryptedTeddy, function(err, res) {
+  if (err) {
+    throw err;
+  }
+
+  bucket.get('person::1', function(err, res) {
+    if (err) {
+      throw err;
+    }
+
+    // Inspecting the data before performing decryption allows us to see
+    // how the document is stored in Couchbase.
+    var encryptedData = res.value;
+    console.log('Encrypted:', encryptedData);
+
+    // Performing decryption on the document will reverse the encryption
+    // process applied above and allow you to view the password in plain-text.
+    var decryptedData =
+        cbfieldcrypt.decryptFields(encryptedData, personCryptFields);
+    console.log('Decrypted:', decryptedData);
+
+    process.exit(0);
+  });
+});
+

--- a/modules/devguide/examples/nodejs/kv-operations.js
+++ b/modules/devguide/examples/nodejs/kv-operations.js
@@ -1,0 +1,467 @@
+/*
+    Sample of various KV Operations
+ */
+
+
+const url = require("url");
+const Hapi = require("hapi");
+const couchbase = require("couchbase");
+
+const options = {username: 'Administrator', password: 'password'};
+const cluster = new couchbase.Cluster("http://localhost", options);
+const bucket = cluster.bucket("travel-sample");
+const collection = bucket.defaultCollection();
+//const collection = bucket.collection("bogus-collection");
+const docKey = 'airport_77';
+const binValKey = 'my-counter-2';
+let document;
+let cas;
+
+const templateDocument = {
+    airportname: "San Clara",
+    city: "Santa Clara",
+    country: "United States",
+    faa: "SCC",
+    geo: {"alt": 62, "lat": -121.928407, "lon": 37.368792},
+    icao: "LFAX",
+    id: 77,
+    type: "airport",
+    tz: "America/Los_Angeles"
+};
+
+function init() {
+    // try to get the cas for later use.  If doc does not exist, create it
+    // #tag::getasync[]
+    collection.get(docKey, {timeout: 1000}, (err, res) => {
+        if (res) {
+            cas = res.cas;
+            document = res.value;
+        } else {
+            if (err.cause.code !== 301 /* something other than document doesn't exist */ ) {
+                console.log(err.toString());
+            } else {
+                try {
+                    console.log("=========== inserting");
+                    collection.insert(docKey, templateDocument,
+                        (err, res) => {
+                            if (res)
+                                cas = res.cas;
+                            document = templateDocument;
+                        }).catch((e) => {
+                        console.log("insert failed with " + e.stack)
+                    });
+                } catch (e) {
+                    console.log("caught in init(1): " + e);
+                }
+            }
+        }
+    }).catch((e) => {
+        console.log("caught in init(2): " + e)
+    });
+// #end::getasync[]
+}
+
+init();
+
+const server = new Hapi.Server({"host": "localhost", "port": 3000});
+
+// handlers for HAPI
+
+async function getHandler(request, h) {
+    const key = request.query.k ? request.query.k : docKey;
+    try {
+        // #tag::get[]
+        const result = await collection.get(key);
+        // #end::get[]
+        cas = result.cas;
+        document = result.value;
+        return h.response(result);
+    } catch (e) {
+        console.log(e);
+        return h.response(e.toString());
+    }
+}
+
+/*
+ * This example returns a promise rather than waiting for the result
+ *
+ */
+async function getwithoptionsHandler(request, h) {
+    const key = request.query.k ? request.query.k : docKey;
+    try { // #tag::getwithoptions[]
+        return collection.get(key, {timeout: 1000},
+            (err, res) => {
+                if (res) {
+                    document = res.value;
+                    cas = res.cas;
+                }
+            }).catch((e) => {
+            console.log(e);
+            return h.response(e.toString() + "<pre>" + e.stack + "</pre>");
+        });
+    } catch (e) { // #end::getwithoptions[]
+        console.log(e);
+        return h.response(e.toString());
+    }
+}
+
+async function insertHandler(request, h) {
+    const key = request.query.k ? request.query.k : docKey;
+    [document.type, document.id] = key.split("_");
+    try {
+        // #tag::insert[]
+        const result = await collection.insert(key, document);
+        // #end::insert[]
+        cas = result.cas;
+        return h.response(result);
+    } catch (e) {
+        console.log(e);
+        return h.response(e.toString() + " - try 'remove' first if document exists");
+    }
+}
+
+async function insertwithoptionsHandler(request, h) {
+    const key = request.query.k ? request.query.k : docKey;
+    [document.type, document.id] = key.split("_");
+    try {
+        // #tag::insertwithoptions[]
+        const result = await collection.insert(key, document, {
+            timeout: 10000, // 10 seconds
+        });
+        // #end::insertwithoptions[]
+        cas = result.cas;
+        return h.response(result);
+    } catch (e) {
+        console.log(e);
+        return h.response(e.toString() + " - try 'remove' first if document exists");
+    }
+}
+
+async function replaceHandler(request, h) {
+    const key = request.query.k ? request.query.k : docKey;
+    try {
+        // #tag::replace[]
+        const result = await collection.replace(key,
+            document, {
+                cas: cas,
+                expiration: 60, // 60 seconds
+                timeout: 5000, // 5 seconds
+            });
+        // #end::replace[]
+        cas = result.cas;
+        return h.response(result);
+    } catch (e) {
+        console.log(e);
+        return h.response(e.toString() + " - try 'get' to get current cas first");
+    }
+}
+
+async function durabilityHandler(request, h) {
+    const key = request.query.k ? request.query.k : docKey;
+    try {
+        // #tag::durability[]
+        let result = await collection.upsert(key, document, {
+            cas: cas,
+            expiration: 60, // 60 seconds
+            persistTo: 1,
+            replicateTo: 1,
+            timeout: 5000, // 5 seconds
+        });
+        // #end::durability[]
+        cas = result.cas;
+        return h.response(result);
+    } catch (e) {
+        console.log(e);
+        return h.response(e.toString() + " - try 'get' to get current cas first");
+    }
+}
+
+async function newdurabilityHandler(request, h) {
+    const key = request.query.k ? request.query.k : docKey;
+    try {
+        // #tag::newdurability[]
+        let result = await collection.upsert(key, document, {
+            cas: cas,
+            expiration: 60, // 60 seconds,
+            durabilityLevel: couchbase.DurabilityLevel.None, // Majority etc.
+            timeout: 5000, // 5 seconds
+        });
+        // #end::newdurability[]
+        cas = result.cas;
+        return h.response(result);
+    } catch (e) {
+        console.log(e);
+        return h.response(e.toString() + " - try 'get' to get current cas first");
+    }
+}
+
+async function removeHandler(request, h) {
+    // if cas is from some other document, this will fail.
+    // is failing a good example of cas?  Or should we
+    // 'get' the document to get the latest cas?
+    const key = request.query.k ? request.query.k : docKey;
+    try {
+        // #tag::remove[]
+        const result = await collection.remove(key, {
+            cas: cas,
+            persistTo: 1,
+            replicateTo: 1,
+            timeout: 5000, // 5 seconds
+        });
+        // #end::remove[]
+        return h.response(result);
+    } catch (e) {
+        console.log(e);
+        if (e.cause.code === 305)
+            return h.response(e.toString() + " - try 'get' to get current cas first");
+        return h.response(e.toString());
+    }
+}
+
+async function touchHandler(request, h) {
+    const key = request.query.k ? request.query.k : docKey;
+    try {
+        // #tag::touch[]
+        const result = await collection.touch(key, 10000);
+        // #end::touch[]
+        return h.response(result);
+    } catch (e) {
+        console.log(e);
+        return h.response(e.toString());
+    }
+}
+
+async function touchwithoptionsHandler(request, h) {
+    const key = request.query.k ? request.query.k : docKey;
+    try {
+        // #tag::touchwithoptions[]
+        const result = await collection.touch(key, 30000, {
+            timeout: 5000, // 5 seconds
+        });
+        // #end::touchwithoptions[]
+        return h.response(result);
+    } catch (e) {
+        console.log(e);
+        return h.response(e.toString());
+    }
+}
+
+async function incrementHandler(request, h) {
+    // #tag::increment[]
+    // increment binary value by 1
+    const result = await collection.binary().increment(binValKey, 1);
+    // #end::increment[]
+    return h.response(result);
+}
+
+async function incrementwithoptionsHandler(request, h) {
+    try {
+        // #tag::incrementwithoptions[]
+        // increment binary value by 1, if binValKey doesn’t exist, seed it at 1000
+        const result = await collection.binary().increment( binValKey, 1,
+            { initial: 1000, timeout: 5000 },
+            (err, res) => {
+                console.log("res: " + JSON.stringify(res));
+            });
+        // #end::incrementwithoptions[]
+        return h.response(result);
+    } catch (e) {
+        if(e.toString() === "Error: bad initial passed")
+		return(h.response("JSCBC-670 must be fixed for 'inital' to be accepted"));
+        console.log(e);
+        return h.response(e.toString());
+    }
+}
+
+async function decrementHandler(request, h) {
+    try {
+        // #tag::decrement[]
+        // decrement binary value by 1
+        const result = await collection.binary().decrement(binValKey, 1);
+        // #end::decrement[]
+        return h.response(result);
+    } catch (e) {
+        console.log(e);
+        return h.response(e.toString());
+    }
+}
+
+async function decrementwithoptionsHandler(request, h) {
+    try {
+        // #tag::decrementwithoptions[]
+        // decrement binary value by 1, if binValKey doesn’t exist, seed it at 1000
+        const result = await collection.binary().decrement(binValKey, 1, {
+            initial: 1000,
+            timeout: 5000
+        });
+        // #end::decrementwithoptions[]
+        return h.response(result);
+    } catch (e) {
+        if(e.toString() === "Error: bad initial passed")
+		return(h.response("JSCBC-670 must be fixed for 'inital' to be accepted"));
+        console.log(e);
+        return h.response(e.toString());
+    }
+}
+
+function usage(request, h) {
+    return h.response(
+        "<table>" +
+        "<tr>" +
+        "<td>" +
+        "<img src=\"http://docs.couchbase.com/_/img/logo.svg\" alt=\"Couchbase\">" +
+        "</td>" +
+        "</tr>" +
+        "<tr><td><a href='get'>/get</a></td></tr>" +
+        "<tr><td><a href='getwithoptions'>/getwithoptions</a></td></tr>" +
+        "<tr><td><a href='insert'>/insert</a></td></tr>" +
+        "<tr><td><a href='insertwithoptions'>/insertwithoptions</a></td></tr>" +
+        "<tr><td><a href='replace'>/replace</a></td></tr>" +
+        "<tr><td><a href='remove'>/remove</a></td></tr>" +
+        "<tr><td><a href='durability'>/durability</a></td></tr>" +
+        "<tr><td><a href='newdurability'>/newdurability</a></td></tr>" +
+        "<tr><td><a href='touch'>/touch</a></td></tr>" +
+        "<tr><td><a href='touchwithoptions'>/touchwithoptions</a></td></tr>" +
+        "<tr><td><a href='increment'>/increment</a></td></tr>" +
+        "<tr><td><a href='incrementwithoptions'>/incrementwithoptions</a></td></tr>" +
+        "<tr><td><a href='decrement'>/decrement</a></td></tr>" +
+        "<tr><td><a href='decrementwithoptions'>/decrementwithoptions</a></td></tr>" +
+        "<tr><td>&nbsp</td></tr>"+
+        "<tr><td><a href='get?k=airport_1254'>/get?k=airport_1254</a></td></tr>" +
+
+        "</table>"
+    );
+}
+
+server.route({
+    method: "GET",
+    path: "/get",
+    handler: async (request, h) => {
+        return await getHandler(request, h);
+    }
+});
+
+server.route({
+    method: "GET",
+    path: "/getwithoptions",
+    handler: async (request, h) => {
+        return await getwithoptionsHandler(request, h);
+    }
+});
+
+server.route({
+    method: "GET",
+    path: "/insert",
+    handler: async (request, h) => {
+        return await insertHandler(request, h);
+    }
+});
+
+server.route({
+    method: "GET",
+    path: "/insertwithoptions",
+    handler: async (request, h) => {
+        return await insertwithoptionsHandler(request, h);
+    }
+});
+
+server.route({
+    method: "GET",
+    path: "/replace",
+    handler: async (request, h) => {
+        return await replaceHandler(request, h);
+    }
+});
+
+server.route({
+    method: "GET",
+    path: "/durability",
+    handler: async (request, h) => {
+        return await durabilityHandler(request, h);
+    }
+});
+
+server.route({
+    method: "GET",
+    path: "/newdurability",
+    handler: async (request, h) => {
+        return await newdurabilityHandler(request, h);
+    }
+});
+
+server.route({
+    method: "GET",
+    path: "/remove",
+    handler: async (request, h) => {
+        return await removeHandler(request, h);
+    }
+});
+
+server.route({
+    method: "GET",
+    path: "/touch",
+    handler: async (request, h) => {
+        return await touchHandler(request, h);
+    }
+});
+
+server.route({
+    method: "GET",
+    path: "/touchwithoptions",
+    handler: async (request, h) => {
+        return await touchwithoptionsHandler(request, h);
+    }
+});
+
+server.route({
+    method: "GET",
+    path: "/increment",
+    handler: async (request, h) => {
+        return await incrementHandler(request, h);
+    }
+});
+
+server.route({
+    method: "GET",
+    path: "/incrementwithoptions",
+    handler: async (request, h) => {
+        return await incrementwithoptionsHandler(request, h);
+    }
+});
+
+server.route({
+    method: "GET",
+    path: "/decrement",
+    handler: async (request, h) => {
+        return await decrementHandler(request, h);
+    }
+});
+
+server.route({
+    method: "GET",
+    path: "/decrementwithoptions",
+    handler: async (request, h) => {
+        return await decrementwithoptionsHandler(request, h);
+    }
+});
+
+server.route({
+    method: "GET",
+    path: "/",
+    handler: (request, h) => {
+        return usage(request, h);
+    }
+});
+
+// start the server
+
+console.log("Starting at " + server.info.uri);
+
+server.start(error => {
+    if (error) {
+        throw error;
+    }
+    console.log("Listening at " + server.info.uri);
+});
+
+

--- a/modules/devguide/examples/nodejs/query-create-index.js
+++ b/modules/devguide/examples/nodejs/query-create-index.js
@@ -1,0 +1,25 @@
+// Require Couchbase Module
+var couchbase = require('couchbase');
+
+// Setup Cluster Connection Object
+var cluster = new couchbase.Cluster('couchbase://127.0.0.1');
+
+// Setup Bucket object to be reused within the code
+var bucket = cluster.openBucket('travel-sample');
+
+// Setup Query
+var N1qlQuery = couchbase.N1qlQuery;
+
+// Make a N1QL specific Query to Create a Primary Index or Secondary Index
+var query = N1qlQuery.fromString("CREATE PRIMARY INDEX ON `travel-sample`");
+
+// Issue Query to Create the Index
+bucket.query(query,function(err,result){
+	if (err) throw err;
+
+	// Print Results
+	console.log("Result:",result);
+
+  console.log('Example Successful - Exiting');
+  process.exit(0);
+});

--- a/modules/devguide/examples/nodejs/query-criteria.js
+++ b/modules/devguide/examples/nodejs/query-criteria.js
@@ -1,0 +1,26 @@
+// Require Couchbase Module
+var couchbase = require('couchbase');
+
+// Setup Cluster Connection Object
+var cluster = new couchbase.Cluster('couchbase://127.0.0.1');
+
+// Setup Bucket object to be reused within the code
+var bucket = cluster.openBucket('travel-sample');
+
+// Setup Query
+var N1qlQuery = couchbase.N1qlQuery;
+
+// Make a N1QL specific Query
+var query = N1qlQuery.fromString("SELECT airportname, city, country FROM `travel-sample` " +
+	"WHERE type='airport' AND city='Reno' ");
+
+// Issue Query
+bucket.query(query,function(err,result){
+	if (err) throw err;
+
+	// Print Results
+	console.log("Result:",result);
+
+  console.log('Example Successful - Exiting');
+  process.exit(0);
+});

--- a/modules/devguide/examples/nodejs/query-placeholders.js
+++ b/modules/devguide/examples/nodejs/query-placeholders.js
@@ -1,0 +1,26 @@
+// Require Couchbase Module
+var couchbase = require('couchbase');
+
+// Setup Cluster Connection Object
+var cluster = new couchbase.Cluster('couchbase://127.0.0.1');
+
+// Setup Bucket object to be reused within the code
+var bucket = cluster.openBucket('travel-sample');
+
+// Setup Query
+var N1qlQuery = couchbase.N1qlQuery;
+
+// Make a N1QL specific Query
+var query = N1qlQuery.fromString("SELECT airportname, city, country FROM `travel-sample` " +
+	"WHERE type=$1 AND city=$2");
+
+// Issue Query with parameters passed in array
+bucket.query(query,["airport","Reno"],function(err,result){
+	if (err) throw err;
+
+	// Print Results
+	console.log("Result:",result);
+
+  console.log('Example Successful - Exiting');
+  process.exit(0);
+});

--- a/modules/devguide/examples/nodejs/query-prepared.js
+++ b/modules/devguide/examples/nodejs/query-prepared.js
@@ -1,0 +1,71 @@
+// Require Couchbase Module
+var couchbase = require('couchbase');
+
+// Setup Cluster Connection Object
+var cluster = new couchbase.Cluster('couchbase://127.0.0.1');
+
+// Setup Bucket object to be reused within the code
+var bucket = cluster.openBucket('travel-sample');
+
+// Setup Query
+var N1qlQuery = couchbase.N1qlQuery;
+
+// Make a N1QL specific Query, telling Couchbase this will be a prepared statement
+var query = N1qlQuery.fromString("SELECT airportname, city, country FROM `travel-sample` " +
+    "WHERE type=$1 AND city=$2").adhoc(false);
+
+// Timing Variables to compare execution times
+var t1,t2,t3,t4;
+
+// QUERY 1 - PREPARE AND EXECUTE
+// Issue Query with parameters passed in array, running as a prepared statement
+bucket.query(query,["airport","London"],function(err,result,meta){
+    if (err) throw err;
+
+    // Print Results
+    console.log("Result:",result);
+    console.log("Time Query1:",meta.metrics.elapsedTime);
+    t1=meta.metrics.elapsedTime;
+
+    // QUERY 2 - EXECUTE THE IDENTICAL QUERY.
+    // Try a the same query, again.  It should have a shorter elapsed time.
+    bucket.query(query,["airport","London"],function(err,result,meta){
+        if(err) throw err;
+
+        // Print Results
+        console.log("Result:",result);
+        console.log("Time Query 2:",meta.metrics.elapsedTime);
+        t2=meta.metrics.elapsedTime;
+
+        // QUERY 3 - EXECUTE THE PLAN
+        // Try the same query, with different parameters.  It should also be fast.
+        bucket.query(query,["airport","Seattle"],function(err,result,meta) {
+            if (err) throw err;
+
+            // Print Results
+            console.log("Result:", result);
+            console.log("Time Query 3:", meta.metrics.elapsedTime);
+            t3=meta.metrics.elapsedTime;
+
+            // QUERY 4 - EXECUTE THE ORIGINAL.
+            // Try the original query, again.
+            bucket.query(query,["airport","London"],function(err,result,meta) {
+                if (err) throw err;
+
+                // Print Results
+                console.log("Result:", result);
+                console.log("Time Query 2:", meta.metrics.elapsedTime);
+                t4 = meta.metrics.elapsedTime;
+
+                console.log("=====");
+                console.log("Query 1 - prepare, execute    :", t1);
+                console.log("Query 2 - execute, same params:", t2);
+                console.log("Query 3 - execute, new params :", t3);
+                console.log("Query 4 - execute, og params  :", t4);
+                console.log("=====");
+                console.log('Example Successful - Exiting');
+                process.exit(0);
+            });
+        });
+    });
+});

--- a/modules/devguide/examples/nodejs/retrieving.js
+++ b/modules/devguide/examples/nodejs/retrieving.js
@@ -1,0 +1,27 @@
+// Require Couchbase Module
+var couchbase = require('couchbase');
+
+// Setup Cluster Connection Object
+var cluster = new couchbase.Cluster('couchbase://127.0.0.1');
+
+// Setup Bucket object to be reused within the code
+var bucket = cluster.openBucket('travel-sample');
+
+// Setup a Document and store in the bucket.
+var key = "nodeDevguideExampleRetrieve";
+bucket.insert(key, {test:"Some Test Value"},function(err, res) {
+    if (err) throw err;
+
+    console.log('Initialized Document, stored to bucket');
+
+    // Get Document
+    bucket.get(key, function (err, resRead) {
+        if (err) throw err;
+
+        // Print Document Value
+        console.log("Retrieved Document:", resRead.value);
+
+        console.log('Example Successful - Exiting');
+        process.exit(0);
+    });
+});

--- a/modules/devguide/examples/nodejs/subdoc.js
+++ b/modules/devguide/examples/nodejs/subdoc.js
@@ -1,0 +1,100 @@
+// Require Couchbase Module
+var couchbase = require('couchbase');
+
+// Setup Cluster Connection Object
+var cluster = new couchbase.Cluster('couchbase://192.168.99.100');
+
+// Setup Bucket object to be reused within the code
+var bucket = cluster.openBucket('travel-sample');
+
+// Setup a new Document and store in the bucket
+var key = "nodeDevguideExampleSubdoc";
+bucket.upsert(key, {
+    firstItem: "Some Test Field Data for firstItem",
+    secondItem: "Some Test Field Data for secondItem",
+    thirdItem: "Some Test Field Data for thirdItem"
+}, function (err, res) {
+    if (err) throw err;
+
+    console.log('Initialized document, stored to bucket...');
+
+    // Get Document
+    bucket.get(key, function (err, resReadFullDoc1) {
+        if (err) throw err;
+
+        // Print Document Value
+        console.log("Retrieve full document:", resReadFullDoc1.value, "\n", "\n");
+
+        // Subdoc Operation: Retrieve Document Fragment for two fields, using
+        //   LookupIn
+        bucket.lookupIn("nodeDevguideExampleSubdoc").
+        get("secondItem").get("thirdItem").
+        execute(function (err, resSubdocOp1) {
+            if (err) throw err;
+
+
+            // Print the values
+            console.log("Retrieve just second and third items:\n", resSubdocOp1.contents, "\n", "\n");
+
+            // Subdoc Operation: Add a fourth item that is an array
+            console.log("Add array to the fourth item of the document...");
+            bucket.mutateIn("nodeDevguideExampleSubdoc", 0, 0).
+            upsert("fourthItem", ["250 GT SWB", "250 GTO", "250 LM", "275 GTB"], true).
+            execute(function (err, resSubdocOp2) {
+                if (err) throw err;
+
+                // Retrieve Full Document
+                bucket.get("nodeDevguideExampleSubdoc", function (err, resReadFullDoc2) {
+                    if (err) throw err;
+
+                    // Print the values
+                    console.log("Retrieve full document with array added to fourth item:\n", resReadFullDoc2.value, "\n", "\n");
+
+                    // Subdoc Operation: Add a value to a specific position, to the "front"
+                    //   of the fourthItem Array, to the "back" of the fourthItem Array, and
+                    //   another unique value to the back of the Array in one operation
+                    console.log("Add a value to a specific position, to the 'front' " +
+                        "of the fourthItem Array, to the 'back' of the fourthItem Array, and " +
+                        "another unique value to the back of the Array in one operation...");
+                    bucket.mutateIn("nodeDevguideExampleSubdoc", 0, 0).
+                    arrayInsert("fourthItem[2]", "250 GTO Series II").
+                    pushFront("fourthItem", "250 GT Lusso", false).
+                    pushBack("fourthItem", "275 GTB/4", false).
+                    addUnique("fourthItem", "288 GTO", false).
+                    execute(function (err, resSubdocOp3) {
+                        if (err) throw err;
+
+                        // LookupIn to retrieve the changes
+                        bucket.lookupIn("nodeDevguideExampleSubdoc").
+                        get("fourthItem").
+                        execute(function (err, resSubdocOp4) {
+                            if (err) throw err;
+
+                            // Print the values
+                            console.log("Retrieve modified fourth item:", resSubdocOp4.contents, "\n", "\n");
+
+                            // Subdoc Operation: Remove a value from the fourthItem Array
+                            console.log("Remove item at position three in fourth item array...")
+                            bucket.mutateIn("nodeDevguideExampleSubdoc", 0, 0).
+                            remove("fourthItem[3]").execute(function (err, resSubdocOp5) {
+                                if (err) throw err;
+
+                                // Subdoc Operation: Retrieve the revised fourth item
+                                bucket.lookupIn("nodeDevguideExampleSubdoc").
+                                get("fourthItem").
+                                execute(function (err, resSubdocOp6) {
+                                    if (err) throw err;
+
+                                    console.log("Retrieved fourth item with array item removed:", resSubdocOp6.contents, "\n", "\n");
+
+                                    console.log('Example Successful - Exiting');
+                                    process.exit(0);
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+});

--- a/modules/devguide/examples/nodejs/subdocES6.js
+++ b/modules/devguide/examples/nodejs/subdocES6.js
@@ -1,0 +1,156 @@
+// This is a Couchbase subdoc api example written using ES6 features.  Please
+//  ensure the version of nodejs installed in your environment is using at
+//  at least version
+'use strict';
+
+// Require Couchbase Module
+var couchbase = require('couchbase');
+
+// Setup Cluster Connection Object
+var cluster = new couchbase.Cluster('couchbase://192.168.99.100');
+
+// Setup Bucket object to be reused within the code
+var bucket = cluster.openBucket('travel-sample');
+
+// Key for example
+var key = "nodeDevguideExampleSubdoc";
+
+// Run the example
+verifyNodejsVersion()
+    .then(storeInitial)
+    .then(lookupEntireDocument)
+    .then(subdocItemLookupTwoFields)
+    .then(subdocArrayAdd)
+    .then(lookupEntireDocument)
+    .then(subdocArrayManipulation)
+    .then(subDocumentItemLookup)
+    .then(subdocArrayRemoveItem)
+    .then(subDocumentItemLookup)
+    .then(() => {
+        process.exit(0);
+    })
+    .catch((err) => {
+        console.log("ERR:", err)
+        process.exit(0);
+    });
+    
+function verifyNodejsVersion() {
+    return new Promise(
+        (resolve, reject) => {
+            if (parseInt(((process.version).split("v"))[1].substr(0, 1)) < 4) {
+                console.log("\n  The nodejs version is too low.  This application requires\n" +
+                    "  ES6 features, specifically: \n" +
+                    "    --promises \n    --arrow functions \n" +
+                    "  Please upgrade the nodejs version from:\n    --Current " +
+                    process.version + "\n    --Minimum:4.0.0");
+                reject();
+            } else resolve();
+        });
+}
+
+function storeInitial() {
+    return new Promise((resolve, reject) => {
+        bucket.upsert(key, {
+            firstItem: "Some Test Field Data for firstItem",
+            secondItem: "Some Test Field Data for secondItem",
+            thirdItem: "Some Test Field Data for thirdItem"
+        }, (err, res) => {
+            if (err) reject(err);
+            else
+            // Print results
+                console.log('Initialized document, stored to bucket...');
+            resolve();
+        });
+    });
+}
+
+function lookupEntireDocument() {
+    return new Promise((resolve, reject) => {
+        // Get Document
+        bucket.get(key, (err, resReadFullDoc) => {
+            if (err) reject(err);
+            else
+            // Print Document Value
+                console.log("Retrieve full document:", resReadFullDoc.value, "\n", "\n");
+            resolve();
+        });
+    });
+}
+
+function subDocumentItemLookup() {
+    return new Promise((resolve, reject) => {
+        // Get Document
+        bucket.lookupIn(key).
+        get("fourthItem").
+        execute((err, resSubdocOp) => {
+            if (err) reject(err);
+            else
+            // Print the values
+                console.log("Retrieve modified fourth item:", resSubdocOp.contents, "\n", "\n");
+            resolve();
+        });
+    });
+}
+
+function subdocItemLookupTwoFields() {
+    return new Promise((resolve, reject) => {
+        // Subdoc Operation: Retrieve Document Fragment for two fields, using LookupIn
+        bucket.lookupIn(key).
+        get("secondItem").get("thirdItem").
+        execute((err, resSubdocOp1) => {
+            if (err) reject(err);
+            else
+            // Print the values
+                console.log("Retrieve just second and third items:\n", resSubdocOp1.contents, "\n", "\n");
+            resolve();
+        });
+    });
+}
+
+function subdocArrayAdd() {
+    console.log("Add array to the fourth item of the document...");
+    return new Promise((resolve, reject) => {
+        bucket.mutateIn(key, 0, 0).
+        upsert("fourthItem", ["250 GT SWB", "250 GTO", "250 LM", "275 GTB"], true).
+        execute((err, resSubdocOp2) => {
+            if (err) reject(err);
+            else
+                resolve();
+        });
+    });
+}
+
+function subdocArrayManipulation() {
+    console.log("Add a value to a specific position, to the 'front' \n" +
+        "  of the fourthItem Array, to the 'back' of the \n" +
+        "  fourthItem Array, and another unique value to \n" +
+        "  the back of the Array in one operation...");
+    return new Promise((resolve, reject) => {
+        // Subdoc Operation: Add a value to a specific position, to the "front"
+        //   of the fourthItem Array, to the "back" of the fourthItem Array, and
+        //   another unique value to the back of the Array in one operation
+        bucket.mutateIn(key, 0, 0).
+        arrayInsert("fourthItem[2]", "250 GTO Series II").
+        pushFront("fourthItem", "250 GT Lusso", false).
+        pushBack("fourthItem", "275 GTB/4", false).
+        addUnique("fourthItem", "288 GTO", false).
+        execute((err, resSubdocOp3)=>{
+            if (err) reject(err);
+            else
+                resolve();
+        });
+    });
+}
+
+function subdocArrayRemoveItem() {
+    console.log("Remove item at position three in fourth item array...");
+    return new Promise((resolve, reject) => {
+        // Subdoc Operation: Remove a value from the fourthItem Array
+        bucket.mutateIn(key, 0, 0).
+        remove("fourthItem[3]").execute((err, resSubdocOp5)=> {
+            if (err) reject(err);
+            else
+                resolve();
+        });
+    });
+}

--- a/modules/devguide/examples/nodejs/updating.js
+++ b/modules/devguide/examples/nodejs/updating.js
@@ -1,0 +1,42 @@
+// Require Couchbase Module
+var couchbase = require('couchbase');
+
+// Setup Cluster Connection Object
+var cluster = new couchbase.Cluster('couchbase://127.0.0.1');
+
+// Setup Bucket object to be reused within the code
+var bucket = cluster.openBucket('travel-sample');
+
+// Setup a new Document and store in the bucket
+var key = "nodeDevguideExampleReplace";
+bucket.insert(key, {test:"Some Test Value"},function(err, res) {
+    if (err) throw err;
+
+    console.log('Initialized Document, stored to bucket');
+
+    // Get Document
+    bucket.get(key, function (err, resRead) {
+        if (err) throw err;
+
+        // Print Document Value
+        console.log("Retrieved Document:", resRead.value);
+
+				// Add to value, and replace
+				resRead.value.test2='Some More Test Values';
+				var updatedVal=JSON.stringify(resRead.value);
+				bucket.replace(key,updatedVal,function(req,resUpdated){
+					if (err) throw err;
+
+					// Get Replaced Document Value
+					bucket.get(key, function (err, resReadUpdated) {
+							if (err) throw err;
+
+							// Print Document Value
+							console.log("Retrieved Document:", resReadUpdated.value);
+
+			        console.log('Example Successful - Exiting');
+			        process.exit(0);
+						});
+				});
+    });
+});

--- a/modules/devguide/examples/striptags.sh
+++ b/modules/devguide/examples/striptags.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+here="`pwd`"
+cd "$(dirname "$0")"
+if [ -z "$gitmod" ] ; then
+	gitmod=0
+fi
+target="$(cd ../../../../devguide-examples ; pwd)" # only 3 ../ if using submodule
+# exclude striptags.sh and non-git files like nodejs/node_modules
+find * |\
+egrep -v '^striptags.sh|^nodejs/node_modules|^nodejs/package-lock.json' |\
+ while read f ; do
+  if [ -d $f ] ; then
+    if [ ! -d $target/$f ] ; then
+        echo Creating directory $target/$f
+	mkdir $target/$f || exit
+	if [ $gitmod -eq 1 ] ; then 
+		echo git add $target/$f
+		( cd $target ; git add $f )
+	fi
+    fi
+  else
+	egrep -v '#tag|#end' $f > /tmp/stripped.$$
+        test  $? -gt 1 && exit
+	diff -q /tmp/stripped.$$ $target/$f 
+        if [ $? -ne 0 ] ; then 
+		mv /tmp/stripped.$$ $target/$f || exit
+		if [ $gitmod -eq 1 ] ; then 
+			echo git add $target/$f
+			( cd $target ; git add $f )
+		fi
+	fi
+  fi
+done
+rm -f /tmp/stripped.$$
+cd "$here"

--- a/modules/howtos/pages/kv-operations.adoc
+++ b/modules/howtos/pages/kv-operations.adoc
@@ -28,8 +28,7 @@ Here is the _Insert_ operation at its simplest:
 .Insert
 [source,javascript]
 ----
-var document = {foo: 'bar', bar: 'foo'};
-var result = await collection.insert('document-key', document);
+include::devguide:example$nodejs/kv-operations.js[tag=insert,indent=0]
 ----
 
 Options may be added to operations:
@@ -37,11 +36,7 @@ Options may be added to operations:
 .Insert (with options)
 [source,javascript]
 ----
-var document = {foo: 'bar', bar: 'foo'};
-var result = await collection.insert('document-key', document, {
-    cas: SOME_CAS,
-    timeout: 10000, // 10 seconds
-});
+include::devguide:example$nodejs/kv-operations.js[tag=insertwithoptions,indent=0]
 ----
 
 Setting a Compare and Swap (CAS) value is a form of optimistic locking - dealt with in depth in the xref:concurrent-document-mutations.adoc[CAS page].
@@ -54,12 +49,7 @@ for the _Replace_ example:
 
 [source,javascript]
 ----
-var document = {foo: 'bar', bar: 'foo'};
-var result = await collection.replace('document-key', document, {
-    cas: SOME_CAS,
-    expiry: 60, // 60 seconds
-    timeout: 5000, // 5 seconds
-});
+include::devguide:example$nodejs/kv-operations.js[tag=replace,indent=0]
 ----
 
 Expiration sets an explicit time to live (TTL) for a document, for which you can also xref:sdk-xattr-example.adoc[see a more detailed example of TTL discovery] later in the docs.
@@ -72,14 +62,7 @@ xref:6.5@server:learn:buckets-memory-and-storage/expiration.adoc#expiration-buck
 
 [source,javascript]
 ----
-var document = {foo: 'bar', bar: 'foo'};
-var result = await collection.Upsert('document-key', document, {
-    cas: SOME_CAS,
-    expiry: 60, // 60 seconds
-    persistTo: 1,
-    replicateTo: 1,
-    timeout: 5000, // 5 seconds
-});
+include::devguide:example$nodejs/kv-operations.js[tag=durability,indent=0]
 ----
 
 Here, we have add _Durability_ options, namely `persistTo` and `replicateTo`.
@@ -103,13 +86,7 @@ The following example demonstrates using the newer durability features available
 
 [source,javascript]
 ----
-var document = {foo: 'bar', bar: 'foo'};
-var result = await collection.Upsert('document-key', document, {
-  case: SOME_CAS,
-  expiry: 60, // 60 seconds,
-  durabilityLevel: couchbase.DurabilityLevel.Majority,
-  timeout: 5000, // 5 seconds
-});
+include::devguide:example$nodejs/kv-operations.js[tag=newdurability,indent=0]
 ----
 
 To stress, durability is a useful feature but should not be the default for most applications, as there is a performance consideration, 
@@ -119,7 +96,7 @@ and the default level of safety provided by Couchbase will be reasonable for the
 .Sub-Document Operations
 ====
 All of these operations involve fetching the complete document from the Cluster.
-Where the number of operations or other circumstances make bandwidth a significant issue, the SDK can work on just a specific _path_ of the document with xref:subdocument-operations.adoc[Sub-Docunent Operations].
+Where the number of operations or other circumstances make bandwidth a significant issue, the SDK can work on just a specific _path_ of the document with xref:subdocument-operations.adoc[Sub-Document Operations].
 ====
 
 == Retrieving full documents
@@ -128,8 +105,7 @@ Using the `get()` method with the document key can be done in a similar fashion 
 
 [source,javascript]
 ----
-var result = await collection.get('document-key');
-var content = result.content;
+include::devguide:example$nodejs/kv-operations.js[tag=get,indent=0]
 ----
 
 Timeout can also be set - as in the earlier `Insert` example:
@@ -137,10 +113,7 @@ Timeout can also be set - as in the earlier `Insert` example:
 .Get (with options)
 [source,javascript]
 ----
-var result = await collection.get('document-key', {
-    timeout: 5000, // 5 seconds
-});
-var content = result.content;
+include::devguide:example$nodejs/kv-operations.js[tag=getwithoptions,indent=0]
 ----
 
 
@@ -151,13 +124,7 @@ When removing a document, you will have the same concern for durability as with 
 .Remove (with options)
 [source,javascript]
 ----
-var result = await collection.remove('document-key', {
-    cas: SOME_CAS,
-    persistTo: 1,
-    replicateTo: 1,
-    timeout: 5000, // 5 seconds
-    }
-);
+include::devguide:example$nodejs/kv-operations.js[tag=remove,indent=0]
 ----
 
 == Expiration / TTL
@@ -167,16 +134,14 @@ Using `touch()`, you can set expiration values on documents to handle transient 
 
 [source,javascript]
 ----
-var result = await collection.touch('document-key', 10000);
+include::devguide:example$nodejs/kv-operations.js[tag=touch,indent=0]
 ----
 
 A network timeout can be set with the options, in the same fashion as earlier examples on this page:
 
 [source,javascript]
 ----
-var result = await collection.touch('document-key', 30000, {
-    timeout: 5000, // 5 seconds
-});
+include::devguide:example$nodejs/kv-operations.js[tag=touchwithoptions,indent=0]
 ----
 
 == Atomic document modifications
@@ -186,35 +151,25 @@ The value of a document can be increased or decreased atomically using `binary()
 .Increment
 [source,javascript]
 ----
-// increment binary value by 1
-await collection.binary().increment('document-key', 1);
+include::devguide:example$nodejs/kv-operations.js[tag=increment,indent=0]
 ----
 
 .Increment (with options)
 [source,javascript]
 ----
-// increment binary value by 1, if document doesn’t exist, seed it at 1000
-await collection.binary().increment('document-key', 1, {
-    initial: 1000,
-    timeout: 5000, // 5 seconds
-});
+include::devguide:example$nodejs/kv-operations.js[tag=incrementwithoptions,indent=0]
 ----
 
 .Decrement
-[source,csharp]
+[source,javascript]
 ----
-// decrement binary value by 1
-await collection.binary().decrement('document-key', 1);
+include::devguide:example$nodejs/kv-operations.js[tag=decrement,indent=0]
 ----
 
 .Decrement (with options)
-[source,csharp]
+[source,javascript]
 ----
-// decrement binary value by 1, if document doesn’t exist, seed it at 1000
-await collection.binary().decrement('document-key', 1, {
-    initial: 1000,
-    cas: SOME_CAS
-});
+include::devguide:example$nodejs/kv-operations.js[tag=decrementwithoptions,indent=0]
 ----
 
 NOTE: Increment & Decrement are considered part of the ‘binary’ API and as such may still be subject to change


### PR DESCRIPTION
Motivation
==========
To ensure that example code in documentation is accurate.

Changes
=======
When example code from devguides-examples is to be used in documentation
it requires (a) to be in a specific directory structure for Antora; and
(b) to be annotated for Antora. As well, we wish to maintain the code
as it was under devguide-examples, without any Antora annotations.
To satisfy all these requirements, files required by the documentation
will be copied to docs-sdk-nodejs/modules/devguide/examples/nodejs/...
and have the appropriate annotations added:
 // #tag::insert[]
 .
 .
 .
 // #end::insert[]
The asciidoctor (adoc) files can then reference the annotated portions
with includes like :
  include::devguide:example$nodejs/kv-operations.js[tag=insert,indent=0]
Note that the Antora identifier does not include a 'component' (repo),
as the kv-operations.js file is in *this* component.  The 'devguide'
refers to the name of the module where the file resides under.
Although only the files that are used in the docs need to be copied/moved
to docs-sdk-nodejs/modules/devguide/examples/nodejs/... , they
could/should all be moved for consistency.