### PR TITLE
DOC-6252 - provide annotated source code for use in documentation

### DIFF
--- a/modules/devguide/examples/nodejs/connecting-cert-auth.js
+++ b/modules/devguide/examples/nodejs/connecting-cert-auth.js
@@ -1,18 +1,35 @@
 // Require Couchbase Module
 var couchbase = require('couchbase');
+var http = require('http');
+const here = process.cwd();
+const truststorepath = here + "/" + '../etc/x509-cert/SSLCA/clientdir/trust.pem';
+const certpath = here + "/" + '../etc/x509-cert/SSLCA/clientdir/client.pem';
+const keypath = here + "/" + '../etc/x509-cert/SSLCA/clientdir'; // gets /client.key from cluster.bucket()
 
 // Setup Cluster Connection Object
+const options = {username: 'testuser', password: 'password'};
 var cluster = new couchbase.Cluster(
-    'couchbases://127.0.0.1/' +
-    '?truststorepath=../etc/x509-cert/SSLCA/clientdir/trust.pem' +
-    '&certpath=../etc/x509-cert/SSLCA/clientdir/client.pem' +
-    '&keypath=../etc/x509-cert/SSLCA/clientdir/client.key');
-
-// Authenticate with the cluster
-cluster.authenticate(new couchbase.CertAuthenticator());
+    'couchbases://127.0.0.1/travel-sample' +
+    '?truststorepath=' + truststorepath +
+    '&certpath=' + certpath +
+    '&keypath=' + keypath, options);
 
 // Setup Bucket object to be reused within the code
-var bucket = cluster.openBucket('travel-sample');
+var bucket = cluster.bucket('client.key');
+const collection = bucket.defaultCollection();
+const docKey = 'airport_1254';
 
-console.log('Example Successful - Exiting');
-process.exit(0);
+var result;
+try {
+    result = collection.get(docKey, {timeout: 1000},
+        (err, res) => {
+            if (res) console.log(JSON.stringify(res));
+            if (err) console.log(err);
+            process.exit(0);
+        })
+        .catch((e) => {
+            console.log(e)
+        });
+} catch (e) {
+    e.printStackTrace();
+}

--- a/modules/devguide/examples/nodejs/connecting-ssl.js
+++ b/modules/devguide/examples/nodejs/connecting-ssl.js
@@ -5,17 +5,48 @@ var couchbase = require('couchbase');
  * Put Self-Signed Cluster Certificate from the cluster
  * to /tmp/couchbase-ssl-certificate.pem:
  *
+ * DO NOT CURL IN CODE AS CURL MAY STILL BE WRITING FILE WHEN CONNECTION STARTS
+ *
  * $ curl http://localhost:8091/pools/default/certificate > /tmp/couchbase-ssl-certificate.pem
+ *
+ * THIS IS WHAT I USED
+ *  Note that the file name is <certpath>/<bucketname> without any extension
+ *
+ * $ curl http://localhost:8091/pools/default/certificate -o /tmp/junk.pem
  */
 
-// Setup Cluster Connection Object
-var cluster = new couchbase.Cluster('couchbase://127.0.0.1?certpath=/tmp/couchbase-ssl-certificate.pem');
+// Setup Cluster Connection Object - must include the bucket name
+// incorrect bucket name here will get you BUCKET_NOT_FOUND
 
-// Authenticate with the cluster
-cluster.authenticate('Administrator', 'password');
+var connString = 'couchbases://127.0.0.1/travel-sample?certpath=/tmp';
+
+// Setup Cluster Connection Object
+
+const options = {username: 'Administrator', password: 'password'};
+var cluster = new couchbase.Cluster(connString, options);
 
 // Setup Bucket object to be reused within the code
-var bucket = cluster.openBucket('travel-sample');
+// 
+// specify bucket again. Actually this does appear to be used for the 
+// name of the bucket. It must be the name of the pem file withing
+// the certpath directory.
+// Mess that up and you will get a generic SSL ERROR
+// 
+const bucket = cluster.bucket("junk.pem"); // specify bucket (again??) - appending to connString makes it work
+const collection = bucket.defaultCollection();
+const docKey = 'airport_1254';
 
-console.log('Example Successful - Exiting');
-process.exit(0);
+var result;
+try {
+    result = collection.get(docKey, {timeout: 1000},
+        (err, res) => {
+            if (res) console.log(JSON.stringify(res));
+            if (err) console.log(err);
+            process.exit(0);
+        })
+        .catch((e) => {
+            console.log(e)
+        });
+} catch (e) {
+    e.printStackTrace();
+}

--- a/modules/devguide/examples/nodejs/connecting.js
+++ b/modules/devguide/examples/nodejs/connecting.js
@@ -2,13 +2,27 @@
 var couchbase = require('couchbase');
 
 // Setup Cluster Connection Object
-var cluster = new couchbase.Cluster('couchbase://127.0.0.1');
-
-// Authenticate with the cluster
-cluster.authenticate('Administrator', 'password');
+var connString = 'couchbase://localhost';
+const options = {username: 'Administrator', password: 'password'};
+var cluster = new couchbase.Cluster(connString, options);
 
 // Setup Bucket object to be reused within the code
-var bucket = cluster.openBucket('travel-sample');
+var bucket = cluster.bucket('travel-sample');
+const collection = bucket.defaultCollection();
+const docKey = 'airport_1254';
 
-console.log('Example Successful - Exiting');
-process.exit(0);
+var result;
+try {
+    result = collection.get(docKey, {timeout: 1000},
+        (err, res) => {
+            if (res) console.log(JSON.stringify(res));
+            if (err) console.log(err);
+            process.exit(0);
+        })
+        .catch((e) => {
+            console.log(e)
+        });
+} catch (e) {
+    e.printStackTrace();
+}
+

--- a/modules/devguide/examples/nodejs/counter.js
+++ b/modules/devguide/examples/nodejs/counter.js
@@ -2,24 +2,24 @@
 var couchbase = require('couchbase');
 
 // Setup Cluster Connection Object
-var cluster = new couchbase.Cluster('couchbase://127.0.0.1');
+const options = {username: 'Administrator', password: 'password'};
+const cluster = new couchbase.Cluster("http://localhost", options);
+const bucket = cluster.bucket("travel-sample");
+const collection = bucket.defaultCollection();
 
-// Setup Bucket object to be reused within the code
-var bucket = cluster.openBucket('travel-sample');
-
-// Setup a new key, initialize as 10, add 2, and retreive it
+// Setup a new key, initialize as 10 (commented out), add 2, and retreive it
 var key = "nodeDevguideExampleCounter";
-bucket.counter(key, 2, {initial: 10}, function(err, res) {
-  if (err) throw err;
 
-  console.log('Initialized Counter:', res.value);
-
-  bucket.counter(key, 2, {initial: 10}, function(err, res) {
+collection.binary().increment(key, 2, /* {initial: 10},*/ function (err, res) {
     if (err) throw err;
 
-    console.log('Incremented Counter:', res.value);
+    console.log('Initialized Counter:', res.value);
 
-    console.log('Example Successful - Exiting');
-    process.exit(0);
-  });
+    collection.binary().increment(key, 2, /* {initial: 10},*/ function (err, res) {
+        if (err) throw err;
+
+        console.log('Incremented Counter:', res.value);
+        console.log('Example Successful - Exiting');
+        process.exit(0);
+    });
 });

--- a/modules/devguide/examples/nodejs/durability.js
+++ b/modules/devguide/examples/nodejs/durability.js
@@ -2,11 +2,12 @@
 var couchbase = require('couchbase');
 
 // Setup Cluster Connection Object
-var cluster = new couchbase.Cluster('couchbase://127.0.0.1');
+const options = {username: 'Administrator', password: 'password'};
+var cluster = new couchbase.Cluster('couchbase://127.0.0.1', options);
 
 // Setup Bucket object to be reused within the code
-var bucket = cluster.openBucket('travel-sample');
-//bucket.durabilityTimeout=10;
+var bucket = cluster.bucket('travel-sample');
+const collection = bucket.defaultCollection();
 
 // Setup a Document and store in the bucket.
 var key = "nodeDevguideExampleDurability";
@@ -32,16 +33,14 @@ function persistExample(done) {
     // Should Always Succeed, even on single node cluster.
     console.log("==========================================");
     console.log("  BEGIN EXAMPLE: Persist To 1 node");
-    bucket.durabilityInterval=1000;
-    bucket.upsert(key, {test: "Some Test Value"}, {persist_to: 1}, function (err, res) {
+    collection.upsert(key+"_1", {test: "Some Test Value 1"}, {durabilityPersistTo: 1}, function (err, res) {
         if (err) throw err;
 
         if (res) {
-            console.log("    CALLBACK: RESULT", res);
             console.log("    Initialized Document, stored to bucket");
 
             // Get Document
-            bucket.get(key, function (err, resRead) {
+            collection.get(key+"_1", function (err, resRead) {
                 if (err) throw err;
 
                 // Print Document Value
@@ -60,17 +59,16 @@ function replicateExample(done) {
     // Should Fail on a single node cluster, succeed on a multi node
     // cluster of 3 or more nodes with at least one replica enabled.
     console.log("==========================================");
-    console.log("  BEGIN EXAMPLE: Replicate To 1 node");
-    bucket.durabilityInterval=1000;
-    bucket.upsert(key, {test: "Some Test Value"}, {replicate_to: 1}, function (err, res) {
+    console.log("  BEGIN EXAMPLE: Replicate To 0 node");
+    collection.upsert(key+"_2", {test: "Some Test Value 2"}, {durabilityReplicateTo: 0}, function (err, res) {
         if (err) throw err;
 
         if (res) {
-            console.log("    CALLBACK: RESULT", res);
+            //console.log("    CALLBACK: RESULT", res);
             console.log("    Initialized Document, stored to bucket");
 
             // Get Document
-            bucket.get(key, function (err, resRead) {
+            collection.get(key+"_2", function (err, resRead) {
                 if (err) throw err;
 
                 // Print Document Value
@@ -90,17 +88,16 @@ function replicateAndPersistExample(done) {
     // a multi node cluster of 3 or more nodes with at least one replica
     // enabled.
     console.log("==========================================");
-    console.log("  BEGIN EXAMPLE: Replicate To and Persist To 1 node");
-    bucket.durabilityInterval=1000;
-    bucket.upsert(key, {test: "Some Test Value"}, {replicate_to: 1, persist_to:1}, function (err, res) {
+    console.log("  BEGIN EXAMPLE: Replicate To 0 and Persist To 1 node");
+    collection.upsert(key+"_3", {test: "Some Test Value 3"}, {durabilityReplicateTo: 0, durabilityPersistTo:1}, function (err, res) {
         if (err) throw err;
 
         if (res) {
-            console.log("    CALLBACK: RESULT", res);
+            //console.log("    CALLBACK: RESULT", res);
             console.log("    Initialized Document, stored to bucket");
 
             // Get Document
-            bucket.get(key, function (err, resRead) {
+            collection.get(key+"_3", function (err, resRead) {
                 if (err) throw err;
 
                 // Print Document Value

--- a/modules/devguide/examples/nodejs/expiration.js
+++ b/modules/devguide/examples/nodejs/expiration.js
@@ -2,33 +2,33 @@
 var couchbase = require('couchbase');
 
 // Setup Cluster Connection Object
-var cluster = new couchbase.Cluster('couchbase://127.0.0.1');
-
-// Setup Bucket object to be reused within the code
-var bucket = cluster.openBucket('travel-sample');
+const options = {username: 'Administrator', password: 'password'};
+const cluster = new couchbase.Cluster("http://localhost", options);
+const bucket = cluster.bucket("travel-sample");
+const collection = bucket.defaultCollection();
 
 // Setup a new Document, with 2 second expiry and store in in the Bucket
 //		 - note -  API uses unix epoch time in seconds
 var key = "nodeDevguideExampleExpiry";
-bucket.insert(key, {test:"Some Test Value"}, {expiry: 2}, function(err, res) {
+collection.insert(key, {test: "Some Test Value"}, {expiry: 2}, function (err, res) {
     if (err) throw err;
 
-    if(res){
+    if (res) {
 
         console.log('Initialized Document With Expiry');
 
         // Get Document before Expiry
-        bucket.get(key, function(err, resPre) {
+        collection.get(key, function (err, resPre) {
             if (err) throw err;
 
-            if(resPre) {
+            if (resPre) {
 
                 console.log('Retreived Document Before Expiry:', resPre.value);
 
                 // Wait 4 seconds, and try to retrieve Document again
                 setTimeout(function () {
-                    bucket.get(key, function (err, resExp) {
-                        if (err){
+                    collection.get(key, function (err, resExp) {
+                        if (err) {
 
                             // Document expired, and should throw an error of not found
                             console.log('Document Expired:', err.message)

--- a/modules/devguide/examples/nodejs/field-encryption.js
+++ b/modules/devguide/examples/nodejs/field-encryption.js
@@ -3,10 +3,10 @@
 var couchbase = require('couchbase');
 var cbfieldcrypt = require('couchbase-encryption');
 
-var cluster = new couchbase.Cluster('couchbase://127.0.0.1');
-cluster.authenticate('Administrator', 'password');
-var bucket = cluster.openBucket('default');
-
+const options = {username: 'Administrator', password: 'password'};
+const cluster = new couchbase.Cluster("http://localhost", options);
+const bucket = cluster.bucket("travel-sample");
+const collection = bucket.defaultCollection();
 
 var publicKey = '!mysecretkey#9^5usdk39d&dlf)03sL';
 var signingKey = 'myauthpassword';
@@ -35,7 +35,7 @@ bucket.upsert('person::1', encryptedTeddy, function(err, res) {
     throw err;
   }
 
-  bucket.get('person::1', function(err, res) {
+  collection.get('person::1', function(err, res) {
     if (err) {
       throw err;
     }

--- a/modules/devguide/examples/nodejs/kv-operations.js
+++ b/modules/devguide/examples/nodejs/kv-operations.js
@@ -1,7 +1,7 @@
 /*
     Sample of various KV Operations
- */
 
+ */
 
 const url = require("url");
 const Hapi = require("hapi");
@@ -11,7 +11,6 @@ const options = {username: 'Administrator', password: 'password'};
 const cluster = new couchbase.Cluster("http://localhost", options);
 const bucket = cluster.bucket("travel-sample");
 const collection = bucket.defaultCollection();
-//const collection = bucket.collection("bogus-collection");
 const docKey = 'airport_77';
 const binValKey = 'my-counter-2';
 let document;
@@ -36,8 +35,9 @@ function init() {
         if (res) {
             cas = res.cas;
             document = res.value;
+            console.log("=========== existing`");
         } else {
-            if (err.cause.code !== 301 /* something other than document doesn't exist */ ) {
+            if (err.cause.code !== 301 /* something other than document doesn't exist */) {
                 console.log(err.toString());
             } else {
                 try {
@@ -88,7 +88,8 @@ async function getHandler(request, h) {
  */
 async function getwithoptionsHandler(request, h) {
     const key = request.query.k ? request.query.k : docKey;
-    try { // #tag::getwithoptions[]
+    try {
+        // #tag::getwithoptions[]
         return collection.get(key, {timeout: 1000},
             (err, res) => {
                 if (res) {
@@ -99,7 +100,8 @@ async function getwithoptionsHandler(request, h) {
             console.log(e);
             return h.response(e.toString() + "<pre>" + e.stack + "</pre>");
         });
-    } catch (e) { // #end::getwithoptions[]
+        // #end::getwithoptions[]
+    } catch (e) {
         console.log(e);
         return h.response(e.toString());
     }
@@ -161,10 +163,9 @@ async function durabilityHandler(request, h) {
     try {
         // #tag::durability[]
         let result = await collection.upsert(key, document, {
-            cas: cas,
             expiration: 60, // 60 seconds
-            persistTo: 1,
-            replicateTo: 1,
+            durabilityPersistTo: 1,
+            durabilityReplicateTo: 0, // anything but 0 will fail on single-node cluster
             timeout: 5000, // 5 seconds
         });
         // #end::durability[]
@@ -181,7 +182,6 @@ async function newdurabilityHandler(request, h) {
     try {
         // #tag::newdurability[]
         let result = await collection.upsert(key, document, {
-            cas: cas,
             expiration: 60, // 60 seconds,
             durabilityLevel: couchbase.DurabilityLevel.None, // Majority etc.
             timeout: 5000, // 5 seconds
@@ -258,16 +258,16 @@ async function incrementwithoptionsHandler(request, h) {
     try {
         // #tag::incrementwithoptions[]
         // increment binary value by 1, if binValKey doesn’t exist, seed it at 1000
-        const result = await collection.binary().increment( binValKey, 1,
-            { initial: 1000, timeout: 5000 },
+        const result = await collection.binary().increment(binValKey, 1,
+            {initial: 1000, timeout: 5000},
             (err, res) => {
                 console.log("res: " + JSON.stringify(res));
             });
         // #end::incrementwithoptions[]
         return h.response(result);
     } catch (e) {
-        if(e.toString() === "Error: bad initial passed")
-		return(h.response("JSCBC-670 must be fixed for 'inital' to be accepted"));
+        if (e.toString() === "Error: bad initial passed")
+            return (h.response("JSCBC-670 must be fixed for 'inital' to be accepted"));
         console.log(e);
         return h.response(e.toString());
     }
@@ -297,8 +297,8 @@ async function decrementwithoptionsHandler(request, h) {
         // #end::decrementwithoptions[]
         return h.response(result);
     } catch (e) {
-        if(e.toString() === "Error: bad initial passed")
-		return(h.response("JSCBC-670 must be fixed for 'inital' to be accepted"));
+        if (e.toString() === "Error: bad initial passed")
+            return (h.response("JSCBC-670 must be fixed for 'inital' to be accepted"));
         console.log(e);
         return h.response(e.toString());
     }
@@ -326,7 +326,7 @@ function usage(request, h) {
         "<tr><td><a href='incrementwithoptions'>/incrementwithoptions</a></td></tr>" +
         "<tr><td><a href='decrement'>/decrement</a></td></tr>" +
         "<tr><td><a href='decrementwithoptions'>/decrementwithoptions</a></td></tr>" +
-        "<tr><td>&nbsp</td></tr>"+
+        "<tr><td>&nbsp</td></tr>" +
         "<tr><td><a href='get?k=airport_1254'>/get?k=airport_1254</a></td></tr>" +
 
         "</table>"

--- a/modules/devguide/examples/nodejs/package.json
+++ b/modules/devguide/examples/nodejs/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "site2",
+  "version": "1.0.0",
+  "description": "Hapi.js site2",
+  "main": "app.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "couchbase",
+  "license": "ISC",
+  "dependencies": {
+    "couchbase": "3.0.0",
+    "hapi": "^18.1.0",
+    "joi": "^14.3.1",
+    "uuid": "^3.3.3"
+  },
+  "devDependencies": {},
+  "keywords": []
+}

--- a/modules/devguide/examples/nodejs/query-create-index.js
+++ b/modules/devguide/examples/nodejs/query-create-index.js
@@ -2,24 +2,24 @@
 var couchbase = require('couchbase');
 
 // Setup Cluster Connection Object
-var cluster = new couchbase.Cluster('couchbase://127.0.0.1');
-
-// Setup Bucket object to be reused within the code
-var bucket = cluster.openBucket('travel-sample');
+const options = {username: 'Administrator', password: 'password'};
+const cluster = new couchbase.Cluster("http://localhost", options);
+const bucket = cluster.bucket("travel-sample");
+const collection = bucket.defaultCollection();
+const docKey = 'airport_77';
 
 // Setup Query
-var N1qlQuery = couchbase.N1qlQuery;
 
 // Make a N1QL specific Query to Create a Primary Index or Secondary Index
-var query = N1qlQuery.fromString("CREATE PRIMARY INDEX ON `travel-sample`");
+var query = "CREATE PRIMARY INDEX ON `travel-sample`";
 
 // Issue Query to Create the Index
-bucket.query(query,function(err,result){
-	if (err) throw err;
+cluster.query(query, function (err, result) {
+    if (err) throw err;
 
-	// Print Results
-	console.log("Result:",result);
+    // Print Results
+    console.log("Result:", result);
 
-  console.log('Example Successful - Exiting');
-  process.exit(0);
+    console.log('Example Successful - Exiting');
+    process.exit(0);
 });

--- a/modules/devguide/examples/nodejs/query-criteria.js
+++ b/modules/devguide/examples/nodejs/query-criteria.js
@@ -2,25 +2,20 @@
 var couchbase = require('couchbase');
 
 // Setup Cluster Connection Object
-var cluster = new couchbase.Cluster('couchbase://127.0.0.1');
-
-// Setup Bucket object to be reused within the code
-var bucket = cluster.openBucket('travel-sample');
-
-// Setup Query
-var N1qlQuery = couchbase.N1qlQuery;
+const options = {username: 'Administrator', password: 'password'};
+const cluster = new couchbase.Cluster("http://localhost", options);
+const bucket = cluster.bucket("travel-sample");
 
 // Make a N1QL specific Query
-var query = N1qlQuery.fromString("SELECT airportname, city, country FROM `travel-sample` " +
-	"WHERE type='airport' AND city='Reno' ");
+const query = "SELECT airportname, city, country FROM `travel-sample` WHERE type='airport' AND city='Reno' ";
 
 // Issue Query
-bucket.query(query,function(err,result){
-	if (err) throw err;
+cluster.query(query, function (err, result) {
+    if (err) throw err;
 
-	// Print Results
-	console.log("Result:",result);
+    // Print Results
+    console.log("Result:", result);
 
-  console.log('Example Successful - Exiting');
-  process.exit(0);
+    console.log('Example Successful - Exiting');
+    process.exit(0);
 });

--- a/modules/devguide/examples/nodejs/query-named.js
+++ b/modules/devguide/examples/nodejs/query-named.js
@@ -1,0 +1,20 @@
+var couchbase = require('couchbase');
+
+// Setup Cluster Connection Object
+const options = {username: 'Administrator', password: 'password'};
+const cluster = new couchbase.Cluster("http://localhost", options);
+const bucket = cluster.bucket("travel-sample");
+
+// Make a N1QL specific Query
+var query = "SELECT airportname, city, country FROM `travel-sample` WHERE type=$TYPE and city=$CITY";
+
+// Issue Query with parameters passed in array
+
+const opts = { parameters : {  TYPE:"airport", CITY:"Reno"} };
+cluster.query(query, opts, function(err,result){
+        console.log(err);
+        if (err) throw err;
+        console.log("Result:",result);
+  console.log('Example Successful - Exiting');
+  process.exit(0);
+});

--- a/modules/devguide/examples/nodejs/query-placeholders.js
+++ b/modules/devguide/examples/nodejs/query-placeholders.js
@@ -1,26 +1,20 @@
-// Require Couchbase Module
 var couchbase = require('couchbase');
 
 // Setup Cluster Connection Object
-var cluster = new couchbase.Cluster('couchbase://127.0.0.1');
-
-// Setup Bucket object to be reused within the code
-var bucket = cluster.openBucket('travel-sample');
-
-// Setup Query
-var N1qlQuery = couchbase.N1qlQuery;
+const options = {username: 'Administrator', password: 'password'};
+const cluster = new couchbase.Cluster("http://localhost", options);
+const bucket = cluster.bucket("travel-sample");
 
 // Make a N1QL specific Query
-var query = N1qlQuery.fromString("SELECT airportname, city, country FROM `travel-sample` " +
-	"WHERE type=$1 AND city=$2");
+var query = "SELECT airportname, city, country FROM `travel-sample` " +
+    "WHERE type=$1 AND city=$2";
 
 // Issue Query with parameters passed in array
-bucket.query(query,["airport","Reno"],function(err,result){
-	if (err) throw err;
 
-	// Print Results
-	console.log("Result:",result);
-
-  console.log('Example Successful - Exiting');
-  process.exit(0);
+cluster.query(query, {parameters: ["airport", "Reno"]}, function (err, result) {
+    console.log(err);
+    if (err) throw err;
+    console.log("Result:", result);
+    console.log('Example Successful - Exiting');
+    process.exit(0);
 });

--- a/modules/devguide/examples/nodejs/query-prepared.js
+++ b/modules/devguide/examples/nodejs/query-prepared.js
@@ -2,66 +2,96 @@
 var couchbase = require('couchbase');
 
 // Setup Cluster Connection Object
-var cluster = new couchbase.Cluster('couchbase://127.0.0.1');
+const options = {username: 'Administrator', password: 'password'};
+const cluster = new couchbase.Cluster("http://localhost", options);
+const bucket = cluster.bucket("travel-sample");
 
-// Setup Bucket object to be reused within the code
-var bucket = cluster.openBucket('travel-sample');
+function log(result) {
+    console.log("Result:", result);
+    console.log(result.meta.profile.phaseCounts);
+    console.log(result.meta.profile.phaseTimes);
+    console.log(result.meta.profile.phaseOperators);
+    console.log("Time :", result.meta.metrics.elapsedTime);
+}
 
-// Setup Query
-var N1qlQuery = couchbase.N1qlQuery;
+function microsSince(hrTime0) {
+    const hrTime = process.hrtime(hrTime0);
+    var micros = hrTime[0] * 1000000 + hrTime[1] / 1000;
+    return micros.toLocaleString();
+}
 
 // Make a N1QL specific Query, telling Couchbase this will be a prepared statement
-var query = N1qlQuery.fromString("SELECT airportname, city, country FROM `travel-sample` " +
-    "WHERE type=$1 AND city=$2").adhoc(false);
+const query = "SELECT airportname, city, country FROM `travel-sample` WHERE type=$1 AND city=$2";
+var opts = {profile: "phases", adhoc: false, parameters: ["airport", "London"]};
 
 // Timing Variables to compare execution times
-var t1,t2,t3,t4;
+var t1, t2, t3, t4;
 
 // QUERY 1 - PREPARE AND EXECUTE
 // Issue Query with parameters passed in array, running as a prepared statement
-bucket.query(query,["airport","London"],function(err,result,meta){
-    if (err) throw err;
+var hrTime1 = process.hrtime()
+cluster.query(query, opts, function (err, result, meta) {
+    console.log("micros: " + microsSince(hrTime1));
+    if (err) {
+        console.log(err);
+        throw err;
+    }
 
     // Print Results
-    console.log("Result:",result);
-    console.log("Time Query1:",meta.metrics.elapsedTime);
-    t1=meta.metrics.elapsedTime;
+    log(result);
+    t1 = result.meta.metrics.elapsedTime;
 
     // QUERY 2 - EXECUTE THE IDENTICAL QUERY.
     // Try a the same query, again.  It should have a shorter elapsed time.
-    bucket.query(query,["airport","London"],function(err,result,meta){
-        if(err) throw err;
+    var hrTime2 = process.hrtime()
+    cluster.query(query, opts, function (err, result, meta) {
+        console.log("micros: " + microsSince(hrTime2));
+        if (err) {
+            console.log(err);
+            throw err;
+        }
 
         // Print Results
-        console.log("Result:",result);
-        console.log("Time Query 2:",meta.metrics.elapsedTime);
-        t2=meta.metrics.elapsedTime;
+        log(result);
+        t2 = result.meta.metrics.elapsedTime;
 
         // QUERY 3 - EXECUTE THE PLAN
         // Try the same query, with different parameters.  It should also be fast.
-        bucket.query(query,["airport","Seattle"],function(err,result,meta) {
-            if (err) throw err;
+        opts = {profile: "phases", adhoc: false, parameters: ["airport", "Seattle"]};
+        var hrTime3 = process.hrtime()
+        cluster.query(query, opts, function (err, result, meta) {
+            console.log("micros: " + microsSince(hrTime3));
+            if (err) {
+                console.log(err);
+                throw err;
+            }
 
             // Print Results
-            console.log("Result:", result);
-            console.log("Time Query 3:", meta.metrics.elapsedTime);
-            t3=meta.metrics.elapsedTime;
+            log(result);
+            console.log(result.meta.metrics.elapsedTime);
+            t3 = result.meta.metrics.elapsedTime;
 
             // QUERY 4 - EXECUTE THE ORIGINAL.
             // Try the original query, again.
-            bucket.query(query,["airport","London"],function(err,result,meta) {
-                if (err) throw err;
+            opts = {profile: "phases", adhoc: false, parameters: ["airport", "London"]};
+            var hrTime4 = process.hrtime()
+            cluster.query(query, opts, function (err, result, meta) {
+                console.log("micros: " + microsSince(hrTime4));
+                if (err) {
+                    console.log(err);
+                    throw err;
+                }
 
                 // Print Results
-                console.log("Result:", result);
-                console.log("Time Query 2:", meta.metrics.elapsedTime);
-                t4 = meta.metrics.elapsedTime;
+                log(result);
+                t4 = result.meta.metrics.elapsedTime;
 
                 console.log("=====");
-                console.log("Query 1 - prepare, execute    :", t1);
-                console.log("Query 2 - execute, same params:", t2);
-                console.log("Query 3 - execute, new params :", t3);
-                console.log("Query 4 - execute, og params  :", t4);
+                console.log("Query 1 - prepare, execute     :", t1);
+                console.log("Query 2 - execute, same params :", t2);
+                console.log("Query 3 - execute, new params  :", t3);
+                console.log(t3);
+                console.log("Query 4 - execute, orig params :", t4);
                 console.log("=====");
                 console.log('Example Successful - Exiting');
                 process.exit(0);

--- a/modules/devguide/examples/nodejs/retrieving.js
+++ b/modules/devguide/examples/nodejs/retrieving.js
@@ -2,26 +2,29 @@
 var couchbase = require('couchbase');
 
 // Setup Cluster Connection Object
-var cluster = new couchbase.Cluster('couchbase://127.0.0.1');
-
-// Setup Bucket object to be reused within the code
-var bucket = cluster.openBucket('travel-sample');
+const options = {username: 'Administrator', password: 'password'};
+const cluster = new couchbase.Cluster("http://localhost", options);
+const bucket = cluster.bucket("travel-sample");
+const collection = bucket.defaultCollection();
 
 // Setup a Document and store in the bucket.
 var key = "nodeDevguideExampleRetrieve";
-bucket.insert(key, {test:"Some Test Value"},function(err, res) {
-    if (err) throw err;
+collection.remove(key, function (err, res) { // remove if already exists
 
-    console.log('Initialized Document, stored to bucket');
-
-    // Get Document
-    bucket.get(key, function (err, resRead) {
+    collection.insert(key, {test: "Some Test Value"}, function (err, res) {
         if (err) throw err;
 
-        // Print Document Value
-        console.log("Retrieved Document:", resRead.value);
+        console.log('Initialized Document, stored to bucket');
 
-        console.log('Example Successful - Exiting');
-        process.exit(0);
+        // Get Document
+        collection.get(key, function (err, resRead) {
+            if (err) throw err;
+
+            // Print Document Value
+            console.log("Retrieved Document:", resRead.value);
+
+            console.log('Example Successful - Exiting');
+            process.exit(0);
+        });
     });
 });

--- a/modules/devguide/examples/nodejs/updating.js
+++ b/modules/devguide/examples/nodejs/updating.js
@@ -2,41 +2,43 @@
 var couchbase = require('couchbase');
 
 // Setup Cluster Connection Object
-var cluster = new couchbase.Cluster('couchbase://127.0.0.1');
-
-// Setup Bucket object to be reused within the code
-var bucket = cluster.openBucket('travel-sample');
+const options = {username: 'Administrator', password: 'password'};
+const cluster = new couchbase.Cluster("http://localhost", options);
+const bucket = cluster.bucket("travel-sample");
+const collection = bucket.defaultCollection();
 
 // Setup a new Document and store in the bucket
 var key = "nodeDevguideExampleReplace";
-bucket.insert(key, {test:"Some Test Value"},function(err, res) {
-    if (err) throw err;
-
-    console.log('Initialized Document, stored to bucket');
-
-    // Get Document
-    bucket.get(key, function (err, resRead) {
+collection.remove(key, function (err, res) {// remove if already exists
+    collection.insert(key, {test: "Some Test Value"}, function (err, res) {
         if (err) throw err;
 
-        // Print Document Value
-        console.log("Retrieved Document:", resRead.value);
+        console.log('Initialized Document, stored to bucket');
 
-				// Add to value, and replace
-				resRead.value.test2='Some More Test Values';
-				var updatedVal=JSON.stringify(resRead.value);
-				bucket.replace(key,updatedVal,function(req,resUpdated){
-					if (err) throw err;
+        // Get Document
+        collection.get(key, function (err, resRead) {
+            if (err) throw err;
 
-					// Get Replaced Document Value
-					bucket.get(key, function (err, resReadUpdated) {
-							if (err) throw err;
+            // Print Document Value
+            console.log("Retrieved Document:", resRead.value);
 
-							// Print Document Value
-							console.log("Retrieved Document:", resReadUpdated.value);
+            // Add to value, and replace
+            resRead.value.test2 = 'Some More Test Values';
+            var updatedVal = JSON.stringify(resRead.value);
+            collection.replace(key, updatedVal, function (req, resUpdated) {
+                if (err) throw err;
 
-			        console.log('Example Successful - Exiting');
-			        process.exit(0);
-						});
-				});
+                // Get Replaced Document Value
+                collection.get(key, function (err, resReadUpdated) {
+                    if (err) throw err;
+
+                    // Print Document Value
+                    console.log("Retrieved Document:", resReadUpdated.value);
+
+                    console.log('Example Successful - Exiting');
+                    process.exit(0);
+                });
+            });
+        });
     });
 });

--- a/modules/devguide/examples/striptags.sh
+++ b/modules/devguide/examples/striptags.sh
@@ -1,13 +1,14 @@
 #!/bin/sh
 here="`pwd`"
 cd "$(dirname "$0")"
+# default is to *not* git add to target
 if [ -z "$gitmod" ] ; then
 	gitmod=0
 fi
-target="$(cd ../../../../devguide-examples ; pwd)" # only 3 ../ if using submodule
-# exclude striptags.sh and non-git files like nodejs/node_modules
+target="$(cd ../../../../sdk-examples ; pwd)" # only 3 ../ if using submodule
+# exclude non-sample code files like nodejs/node_modules
 find * |\
-egrep -v '^striptags.sh|^nodejs/node_modules|^nodejs/package-lock.json' |\
+egrep -v '^striptags|^nodejs/node_modules|^nodejs/package-lock.json' |\
  while read f ; do
   if [ -d $f ] ; then
     if [ ! -d $target/$f ] ; then
@@ -21,8 +22,9 @@ egrep -v '^striptags.sh|^nodejs/node_modules|^nodejs/package-lock.json' |\
   else
 	egrep -v '#tag|#end' $f > /tmp/stripped.$$
         test  $? -gt 1 && exit
-	diff -q /tmp/stripped.$$ $target/$f 
+	diff -q /tmp/stripped.$$ $target/$f  > /dev/null
         if [ $? -ne 0 ] ; then 
+		echo copied stripped version of $f to $target/$f 
 		mv /tmp/stripped.$$ $target/$f || exit
 		if [ $gitmod -eq 1 ] ; then 
 			echo git add $target/$f

--- a/modules/devguide/examples/striptags.sh
+++ b/modules/devguide/examples/striptags.sh
@@ -21,8 +21,9 @@ egrep -v '^striptags.sh|^nodejs/node_modules|^nodejs/package-lock.json' |\
   else
 	egrep -v '#tag|#end' $f > /tmp/stripped.$$
         test  $? -gt 1 && exit
-	diff -q /tmp/stripped.$$ $target/$f 
+	diff -q /tmp/stripped.$$ $target/$f  > /dev/null
         if [ $? -ne 0 ] ; then 
+		echo copied stripped version of $f to $target/$f 
 		mv /tmp/stripped.$$ $target/$f || exit
 		if [ $gitmod -eq 1 ] ; then 
 			echo git add $target/$f


### PR DESCRIPTION
Motivation
==========
To ensure that example code in documentation is accurate.

Changes
=======
When example code from devguides-examples is to be used in documentation
it requires (a) to be in a specific directory structure for Antora; and
(b) to be annotated for Antora. As well, we wish to maintain the code
as it was under devguide-examples, without any Antora annotations.
To satisfy all these requirements, files required by the documentation
will be copied to docs-sdk-nodejs/modules/devguide/examples/nodejs/...
and have the appropriate annotations added:
 // #tag::insert[]
 .
 .
 .
 // #end::insert[]
The asciidoctor (adoc) files can then reference the annotated portions
with includes like :
  include::devguide:example$nodejs/kv-operations.js[tag=insert,indent=0]
Note that the Antora identifier does not include a 'component' (repo),
as the kv-operations.js file is in *this* component.  The 'devguide'
refers to the name of the module where the file resides under.
Although only the files that are used in the docs need to be copied/moved
to docs-sdk-nodejs/modules/devguide/examples/nodejs/... , they
could/should all be moved for consistency.