### PR TITLE
DEVADV-188 Update n1ql-queries-with-sdk page in Node.js 3 docs

### DIFF
--- a/modules/devguide/examples/nodejs/n1ql-queries.js
+++ b/modules/devguide/examples/nodejs/n1ql-queries.js
@@ -1,70 +1,74 @@
-
 var couchbase = require('couchbase');
 
-// Setup Cluster Connection Object
-const options = {username: 'Administrator', password: 'password'};
-const cluster = new couchbase.Cluster("http://localhost", options);
+const cluster = new couchbase.Cluster(
+  'couchbase://localhost',
+  { username: 'Administrator', password: 'password' }
+)
 const bucket = cluster.bucket("travel-sample");
 const collection = bucket.defaultCollection();
 
-
-function start(){
+function start() {
   console.log("start");
- return new Promise( (resolve, reject) => { resolve(); });
-
+  return new Promise((resolve, reject) => resolve());
 }
 
-async function queryplaceholders(){
-  // Make a N1QL specific Query
-  // #tag::queryplaceholders[]
-  var query = "SELECT airportname, city, country FROM `travel-sample` " +
-      "WHERE type=$1 AND city=$2";
-  
-  // Issue Query with parameters passed in array
-  
-  var result=await cluster.query(query, {parameters: ["airport", "Reno"]}, function (err, res) {
-      console.log(err);
-      if (err) throw err;
-      console.log("Result:", res);
-  });
-  // #end::queryplaceholders[]
+// #tag::queryplaceholders[]
+const queryPlaceholders = async () => {
+  const query = `
+    SELECT airportname, city FROM \`travel-sample\` 
+    WHERE type=$1 
+      AND city=$2
+  `;
+  const options = { parameters: ['airport', 'San Jose'] }
+
+  try {
+    let result = await cluster.query(query, options)
+    console.log("Result:", result)
+    return result
+  } catch (error) {
+    console.error('Query failed: ', error)
+  }
 }
+// #end::queryplaceholders[]
 
-async function querynamed(){
+// #tag::querynamed[]
+const queryNamed = async () => {
+  const query = `
+    SELECT airportname, city FROM \`travel-sample\` 
+    WHERE type=$TYPE 
+      AND city=$CITY;
+  `
+  const options = { parameters: { TYPE: 'airport', CITY: 'Reno' } }
 
-  // Make a N1QL specific Query
-  // #tag::querynamed[]
-  var query = "SELECT airportname, city, country FROM `travel-sample` WHERE type=$TYPE and city=$CITY";
-  
-  // Issue Query with parameters passed in objects
-  
-  const opts = { parameters : {  TYPE:"airport", CITY:"Reno"} };
-  var result=await cluster.query(query, opts, function(err,res){
-          console.log(err);
-          if (err) throw err;
-          console.log("Result:",res);
-  });
-  // #end::querynamed[]
+  try {
+    let result = await cluster.query(query, options)
+    console.log("Result:", result)
+    return result
+  } catch (error) {
+    console.error('Query failed: ', error)
+  }
 }
-async function queryresults(){
+// #end::querynamed[]
 
-  // Make a N1QL specific Query
-  var query = "SELECT airportname, city, country FROM `travel-sample` WHERE type=$TYPE and city=$CITY";
-  
-  // Issue Query with parameters passed in objects
-  
-  // #tag::queryresults[]
-  const opts = { parameters : {  TYPE:"airport", CITY:"Reno"} };
-  var result=cluster.query(query, opts, function(err,res){
-          console.log(err);
-          if (err) throw err;
-          res.rows.forEach((row)=>{
-             console.log("row :");
-             console.log(row);
-          });
-  });
-  // #end::queryresults[]
-} 
+// #tag::queryresults[]
+const queryResults = async () => {
+  const query = `
+  SELECT airportname, city FROM \`travel-sample\` 
+  WHERE type='airport' 
+    AND tz LIKE '%Los_Angeles' 
+    AND airportname LIKE '%Intl';
+  `
+  try {
+    let results = await cluster.query(query);
+    results.rows.forEach((row) => {
+      console.log('Query row: ', row)
+    })
+    return results
+  } catch (error) {
+    console.error('Query failed: ', error)
+  }
+}
+// #end::queryresults[]
 
 /*** Not implemented
 async function queryresultson(){
@@ -102,8 +106,8 @@ var result = await cluster.query(
 
 
 start()
- .then(queryplaceholders)
- .then(querynamed)
- .then(queryresults)
+  .then(queryPlaceholders)
+  .then(queryNamed)
+  .then(queryResults)
  //.then(queryresultson)
  //.then(querystate)

--- a/modules/devguide/examples/nodejs/n1ql-queries.js
+++ b/modules/devguide/examples/nodejs/n1ql-queries.js
@@ -7,9 +7,8 @@ const cluster = new couchbase.Cluster(
 const bucket = cluster.bucket("travel-sample");
 const collection = bucket.defaultCollection();
 
-function start() {
-  console.log("start");
-  return new Promise((resolve, reject) => resolve());
+async function start() {
+  console.log('start')
 }
 
 // #tag::queryplaceholders[]

--- a/modules/devguide/examples/nodejs/n1ql-queries.js
+++ b/modules/devguide/examples/nodejs/n1ql-queries.js
@@ -12,7 +12,7 @@ async function start() {
 }
 
 // #tag::queryplaceholders[]
-const queryPlaceholders = async () => {
+async function queryPlaceholders() {
   const query = `
     SELECT airportname, city FROM \`travel-sample\` 
     WHERE type=$1 
@@ -31,7 +31,7 @@ const queryPlaceholders = async () => {
 // #end::queryplaceholders[]
 
 // #tag::querynamed[]
-const queryNamed = async () => {
+async function queryNamed() {
   const query = `
     SELECT airportname, city FROM \`travel-sample\` 
     WHERE type=$TYPE 
@@ -50,7 +50,7 @@ const queryNamed = async () => {
 // #end::querynamed[]
 
 // #tag::queryresults[]
-const queryResults = async () => {
+async function queryResults() {
   const query = `
   SELECT airportname, city FROM \`travel-sample\` 
   WHERE type='airport' 

--- a/modules/devguide/examples/nodejs/query-named.js
+++ b/modules/devguide/examples/nodejs/query-named.js
@@ -1,7 +1,7 @@
 var couchbase = require('couchbase');
 
 // Setup Cluster Connection Object
-const options = {username: 'Administrator', password: 'password'};
+const options = { username: 'Administrator', password: 'password' };
 const cluster = new couchbase.Cluster("http://localhost", options);
 const bucket = cluster.bucket("travel-sample");
 
@@ -11,16 +11,16 @@ var query = "SELECT airportname, city, country FROM `travel-sample` WHERE type=$
 
 // Issue Query with parameters passed in objects
 
-const opts = { parameters : {  TYPE:"airport", CITY:"Reno"} };
-cluster.query(query, opts, function(err,result){
-        console.log(err);
-        if (err) throw err;
-        console.log("Result:",result);
-        result.rows.forEach((row)=>{
-           console.log("row :");
-           console.log(row);
-        });
-        console.log('Example Successful - Exiting');
-        process.exit(0);
-}).catch((e)=> console.log(e));
+const opts = { parameters: { TYPE: "airport", CITY: "Reno" } };
+cluster.query(query, opts, function (err, result) {
+    console.log(err);
+    if (err) throw err;
+    console.log("Result:", result);
+    result.rows.forEach((row) => {
+        console.log("row :");
+        console.log(row);
+    });
+    console.log('Example Successful - Exiting');
+    process.exit(0);
+}).catch((e) => console.log(e));
 // #end::select[]

--- a/modules/howtos/pages/n1ql-queries-with-sdk.adoc
+++ b/modules/howtos/pages/n1ql-queries-with-sdk.adoc
@@ -8,10 +8,7 @@ You can query for documents in Couchbase using the N1QL query language, a langua
 
 Our query service uses N1QL, which will be fairly familiar to anyone who's used any dialect of SQL. xref:#additional-resources[Additional resources] for learning about N1QL are listed at the bottom of the page.
 
-Before you get started you may wish to checkout the xref:6.5@server:n1ql:n1ql-language-reference/index.adoc[N1QL intro page], or just dive in with a query against our travel-sample data set.
-In this case, the one thing that you need to know is that in order to make a Bucket queryable, it must have at least one index defined.
-You can define a _primary_ index on a bucket.
-When a primary index is defined you can issue non-covered queries on the bucket as well.
+Before you get started you may wish to check out the xref:6.5@server:n1ql:n1ql-language-reference/index.adoc[N1QL intro page], or just dive in with a query against our travel-sample data set. To make a Bucket queryable, it must have at least one index defined. You can define a _primary_ index on a bucket. While not recommended for production, defining a primary index is great for ad-hoc queries that are great for exploring your data, the reason they are not recommended for production is that they enable a full-bucket scan.
 
 Use
 xref:6.5@server:tools:cbq-shell.html[cbq], our interactive Query shell.
@@ -27,7 +24,6 @@ or replace _travel-sample_ with a different Bucket name to build an index on a d
 NOTE: The default installation places cbq in `/opt/couchbase/bin/` on Linux, `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/cbq` on OS X, and `C:\Program Files\Couchbase\Server\bin\cbq.exe` on Microsoft Windows.
 
 // TODO: improving this and/or adding server/6.0/tools/query-workbench.html
-
 
 == Queries & Placeholders
 

--- a/modules/howtos/pages/n1ql-queries-with-sdk.adoc
+++ b/modules/howtos/pages/n1ql-queries-with-sdk.adoc
@@ -112,12 +112,11 @@ include::devguide:example$nodejs/n1ql-queries.js[tag=querynamed,indent=0]
 
 == Additional Resources
 
-NOTE: N1QL is not the only query option in Couchbase.
-Be sure to check that your use case fits your selection of query service.
+NOTE: N1QL is not the only query option in Couchbase. Be sure to check that your use case fits your selection of query service.
 
 // For a deeper dive into N1QL from the SDK, refer to our xref:concept:[N1QL SDK concept doc].
 
-The xref:6.0@server:n1ql:n1ql-language-reference/index.adoc[Server doc N1QL intro] introduces up a complete guide to the N1QL language, including all of the latest additions.
+The xref:6.5@server:n1ql:n1ql-language-reference/index.adoc[N1QL Language Reference] introduces up a complete guide to the N1QL language, including all of the latest additions.
 
 The http://query.pub.couchbase.com/tutorial/#1[N1QL interactive tutorial] is a good introduction to the basics of N1QL use.
 

--- a/modules/howtos/pages/n1ql-queries-with-sdk.adoc
+++ b/modules/howtos/pages/n1ql-queries-with-sdk.adoc
@@ -11,7 +11,7 @@ Our query service uses N1QL, which will be fairly familiar to anyone who's used 
 Before you get started you may wish to check out the xref:6.5@server:n1ql:n1ql-language-reference/index.adoc[N1QL intro page], or just dive in with a query against our travel-sample data set. To make a Bucket queryable, it must have at least one index defined. You can define a _primary_ index on a bucket. While not recommended for production, defining a primary index is great for ad-hoc queries that are great for exploring your data, the reason they are not recommended for production is that they enable a full-bucket scan.
 
 Use
-xref:6.5@server:tools:cbq-shell.html[cbq], our interactive Query shell.
+xref:6.5@server:tools:cbq-shell.adoc[cbq], our interactive Query shell.
 Open it, and enter the following:
 
 [source,n1ql]
@@ -45,11 +45,10 @@ include::devguide:example$nodejs/n1ql-queries.js[tag=querynamed,indent=0]
 
 == Handling Results
 
-In most cases your query will return more than one result, and you may be looking to iterate over those results:
-// this is the same as the above "query-named" as it also shows processing results
+Most queries return more than one result, and you want to iterate over the results:
 [source,javascript]
 ----
-include::devguide:example$nodejs/n1ql-queries.js[tag=querynamed,indent=0]
+include::devguide:example$nodejs/n1ql-queries.js[tag=queryresults,indent=0]
 ----
 
 //== Scan Consistency
@@ -69,10 +68,10 @@ include::devguide:example$nodejs/n1ql-queries.js[tag=querynamed,indent=0]
 //.ScanConsisteny (RYOW)
 //[source,javascript]
 //----
-//// create / update document (mutation)
+// // create / update document (mutation)
 //var upsertResult = await collection.upsert('id', {name: 'Mike', type: 'User'});
 //
-//// create mutation state from mutation results
+// // create mutation state from mutation results
 //var state = couchbase.MutationState.from(upsertResult);
 //
 // use mutation state with query option
@@ -115,4 +114,3 @@ The http://query.pub.couchbase.com/tutorial/#1[N1QL interactive tutorial] is a g
 // Indexes / GSI links?
 
 // SQL++ / Analytics.
-

--- a/modules/howtos/pages/n1ql-queries-with-sdk.adoc
+++ b/modules/howtos/pages/n1ql-queries-with-sdk.adoc
@@ -7,9 +7,8 @@
 You can query for documents in Couchbase using the N1QL query language, a language based on SQL, but designed for structured and flexible JSON documents.
 Querying can solve typical programming tasks such as finding a user profile by email address, facebook login, or user ID.
 
-
 Our query service uses N1QL, which will be fairly familiar to anyone who's used any dialect of SQL.
-xref:#additional_resources[Further resources] for learning about N1QL are listed at the bottom of the page.
+xref:#additional-resources[Additional resources] for learning about N1QL are listed at the bottom of the page.
 Before you get started you may wish to checkout the xref:6.5@server:n1ql:n1ql-language-reference/index.adoc[N1QL intro page], or just dive in with a query against our travel sample data set.
 In this case, the one thing that you need to know is that in order to make a Bucket queryable, it must have at least one index defined.
 You can define a _primary_ index on a bucket.

--- a/modules/howtos/pages/n1ql-queries-with-sdk.adoc
+++ b/modules/howtos/pages/n1ql-queries-with-sdk.adoc
@@ -4,12 +4,11 @@
 :page-aliases: n1ql-query
 
 [abstract]
-You can query for documents in Couchbase using the N1QL query language, a language based on SQL, but designed for structured and flexible JSON documents.
-Querying can solve typical programming tasks such as finding a user profile by email address, facebook login, or user ID.
+You can query for documents in Couchbase using the N1QL query language, a language based on SQL, but designed for structured and flexible JSON documents. Querying can solve typical programming tasks such as finding a user profile by email address, Facebook login, or user ID.
 
-Our query service uses N1QL, which will be fairly familiar to anyone who's used any dialect of SQL.
-xref:#additional-resources[Additional resources] for learning about N1QL are listed at the bottom of the page.
-Before you get started you may wish to checkout the xref:6.5@server:n1ql:n1ql-language-reference/index.adoc[N1QL intro page], or just dive in with a query against our travel sample data set.
+Our query service uses N1QL, which will be fairly familiar to anyone who's used any dialect of SQL. xref:#additional-resources[Additional resources] for learning about N1QL are listed at the bottom of the page.
+
+Before you get started you may wish to checkout the xref:6.5@server:n1ql:n1ql-language-reference/index.adoc[N1QL intro page], or just dive in with a query against our travel-sample data set.
 In this case, the one thing that you need to know is that in order to make a Bucket queryable, it must have at least one index defined.
 You can define a _primary_ index on a bucket.
 When a primary index is defined you can issue non-covered queries on the bucket as well.
@@ -33,7 +32,7 @@ NOTE: The default installation places cbq in `/opt/couchbase/bin/` on Linux, `/A
 == Queries & Placeholders
 
 Placeholders allow you to specify variable constraints for an otherwise constant query.
-There are two variants of placeholders: postional and named parameters.
+There are two variants of placeholders: positional and named parameters.
 Positional parameters use an ordinal placeholder for substitution and named parameters use variables.
 A named or positional parameter is a placeholder for a value in the WHERE, LIMIT or OFFSET clause of a query.
 Note that both parameters and options are optional.
@@ -51,8 +50,6 @@ include::devguide:example$nodejs/n1ql-queries.js[tag=querynamed,indent=0]
 ----
 
 // The complete code for this page's example can be found at xref:[??]
-
-
 
 == Handling Results
 

--- a/modules/howtos/pages/n1ql-queries-with-sdk.adoc
+++ b/modules/howtos/pages/n1ql-queries-with-sdk.adoc
@@ -27,11 +27,7 @@ NOTE: The default installation places cbq in `/opt/couchbase/bin/` on Linux, `/A
 
 == Queries & Placeholders
 
-Placeholders allow you to specify variable constraints for an otherwise constant query.
-There are two variants of placeholders: positional and named parameters.
-Positional parameters use an ordinal placeholder for substitution and named parameters use variables.
-A named or positional parameter is a placeholder for a value in the WHERE, LIMIT or OFFSET clause of a query.
-Note that both parameters and options are optional.
+Placeholders allow you to specify variable constraints for an otherwise constant query. There are two variants of placeholders: positional and named parameters. Positional parameters use an ordinal placeholder for substitution and named parameters use variables. A named or positional parameter is a placeholder for a value in the WHERE, LIMIT or OFFSET clause of a query. Note that both parameters and options are optional.
 
 .Positional parameter example:
 [source,javascript]

--- a/modules/howtos/pages/n1ql-queries-with-sdk.adoc
+++ b/modules/howtos/pages/n1ql-queries-with-sdk.adoc
@@ -4,14 +4,18 @@
 :page-aliases: n1ql-query
 
 [abstract]
-You can query for documents in Couchbase using the N1QL query language, a language based on SQL, but designed for structured and flexible JSON documents. Querying can solve typical programming tasks such as finding a user profile by email address, Facebook login, or user ID.
+You can query for documents in Couchbase using the N1QL query language, a language based on SQL, but designed for structured and flexible JSON documents. 
+Querying can solve typical programming tasks such as finding a user profile by email address, Facebook login, or user ID.
 
-Our query service uses N1QL, which will be fairly familiar to anyone who's used any dialect of SQL. xref:#additional-resources[Additional resources] for learning about N1QL are listed at the bottom of the page.
+Our query service uses N1QL, which will be fairly familiar to anyone who's used any dialect of SQL. 
+xref:#additional-resources[Additional resources] for learning about N1QL are listed at the bottom of the page.
 
-Before you get started you may wish to check out the xref:6.5@server:n1ql:n1ql-language-reference/index.adoc[N1QL intro page], or just dive in with a query against our travel-sample data set. To make a Bucket queryable, it must have at least one index defined. You can define a _primary_ index on a bucket. While not recommended for production, defining a primary index is great for ad-hoc queries that are great for exploring your data, the reason they are not recommended for production is that they enable a full-bucket scan.
+Before you get started you may wish to check out the xref:6.5@server:n1ql:n1ql-language-reference/index.adoc[N1QL intro page], or just dive in with a query against our travel-sample data set. 
+To make a Bucket queryable, it must have at least one index defined. 
+You can define a _primary_ index on a bucket. 
+While not recommended for production, defining a primary index is useful for ad hoc queries that are great for exploring your data, the reason they are not recommended for production is that they enable a full-bucket scan.
 
-Use
-xref:6.5@server:tools:cbq-shell.adoc[cbq], our interactive Query shell.
+Use xref:6.5@server:tools:cbq-shell.adoc[cbq], our interactive Query shell.
 Open it, and enter the following:
 
 [source,n1ql]
@@ -27,7 +31,11 @@ NOTE: The default installation places cbq in `/opt/couchbase/bin/` on Linux, `/A
 
 == Queries & Placeholders
 
-Placeholders allow you to specify variable constraints for an otherwise constant query. There are two variants of placeholders: positional and named parameters. Positional parameters use an ordinal placeholder for substitution and named parameters use variables. A named or positional parameter is a placeholder for a value in the WHERE, LIMIT or OFFSET clause of a query. Note that both parameters and options are optional.
+Placeholders allow you to specify variable constraints for an otherwise constant query. 
+There are two variants of placeholders: positional and named parameters. 
+Positional parameters use an ordinal placeholder for substitution and named parameters use variables. 
+A named or positional parameter is a placeholder for a value in the WHERE, LIMIT, or OFFSET clause of a query. 
+Note that both parameters and options are optional.
 
 .Positional parameter example:
 [source,javascript]
@@ -103,7 +111,8 @@ include::devguide:example$nodejs/n1ql-queries.js[tag=queryresults,indent=0]
 
 == Additional Resources
 
-NOTE: N1QL is not the only query option in Couchbase. Be sure to check that your use case fits your selection of query service.
+NOTE: N1QL is not the only query option in Couchbase. 
+Be sure to check that your use case fits your selection of query service.
 
 // For a deeper dive into N1QL from the SDK, refer to our xref:concept:[N1QL SDK concept doc].
 

--- a/modules/howtos/pages/n1ql-queries-with-sdk.adoc
+++ b/modules/howtos/pages/n1ql-queries-with-sdk.adoc
@@ -19,7 +19,7 @@ Open it, and enter the following:
 CREATE PRIMARY INDEX ON `travel-sample`
 ----
 
-or replace _travel-sample_ with a different Bucket name to build an index on a different dataset.
+By replacing _travel-sample_ with a different Bucket, you can build an index on your bucket of choice.
 
 NOTE: The default installation places cbq in `/opt/couchbase/bin/` on Linux, `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/cbq` on OS X, and `C:\Program Files\Couchbase\Server\bin\cbq.exe` on Microsoft Windows.
 


### PR DESCRIPTION
The current query page has incomplete and duplicated code samples. Together with Brett Lawson, I have determined a suitable format that we should be using for our code samples, updated the `n1ql-queries.js` page from which our code samples are being pulled from, adjusted the amount of code shown to include the full async function surrounding the code sample and wrapped the query operations in try/catch blocks.

Below is the output showing the code samples (`n1ql-queries.js`) work.
![Screen Shot 2020-05-19 at 10 58 55 AM](https://user-images.githubusercontent.com/4899480/82363090-37608900-99c2-11ea-98d4-b53d4cc7c85e.png)


