### PR TITLE
DEVADV-247 Update code sample include for package.json in start-using-sdk

### DIFF
--- a/modules/hello-world/examples/getting-started/package.json
+++ b/modules/hello-world/examples/getting-started/package.json
@@ -1,3 +1,4 @@
+  // tag::start-using-package-json[]
 {
   "name": "node-couchbase-project",
   "version": "1.0.0",
@@ -13,3 +14,4 @@
     "couchbase": "^3.0.2"
   }
 }
+// end::start-using-package-json[]

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -3,7 +3,7 @@
 :navtitle: Start Using the SDK
 
 [abstract]
-The Couchbase Node.js SDK enables you to interact with a Couchbase Server cluster from the link:https://nodejs.org/en/about/[Node.js language].
+The Couchbase Node.js SDK enables you to interact with a Couchbase Server cluster from the link:https://nodejs.org/[Node.js language].
 
 The Couchbase Node.js SDK 3.0 is a complete rewrite of the API, reducing the number of overloads to present a simplified surface area, and adding support for future Couchbase Server features like Collections and Scopes (available in Couchbase Server 6.5 as xref:concept-docs:collections.adoc[a developer preview]).
 

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -3,7 +3,7 @@
 :navtitle: Start Using the SDK
 
 [abstract]
-The Couchbase Node.js SDK enables you to interact with a Couchbase Server cluster from the link:https://nodejs.org/[Node.js language].
+The Couchbase Node.js SDK enables you to interact with a Couchbase Server cluster from the link:https://nodejs.org/en/about/[Node.js language].
 
 The Couchbase Node.js SDK 3.0 is a complete rewrite of the API, reducing the number of overloads to present a simplified surface area, and adding support for future Couchbase Server features like Collections and Scopes (available in Couchbase Server 6.5 as xref:concept-docs:collections.adoc[a developer preview]).
 
@@ -36,14 +36,14 @@ If a directory does not already have a `package.json` at its root, this means it
 
 Note: We have used the `-y` flag to take the initialization defaults. To change any of these defaults, just open the `package.json` and manually make any changes. 
 
-[source,json]
+[source,json,indent=0]
 ----
-include::../examples/getting-started/package.json
+include::../examples/getting-started/package.json[tag=start-using-package-json]
 ----
 
 == Installing the SDK
 
-The Couchbase Node.js Client will run on any https://github.com/nodejs/Release[supported LTS version of Node.js] -- currently, 10.x, and 12.x.
+The Couchbase Node.js Client will run on any https://nodejs.org/en/download/[supported LTS version of Node.js].
 
 [source,bash]
 ----


### PR DESCRIPTION
Related to JIRA TIcket: https://issues.couchbase.com/browse/DEVADV-247

The Start-using page has been updated and code samples have been moved to another page this has created an issue where the package.json code that was originally inline is not showing up, I am creating a PR to fix this.

Also, update the link to NodeJS downloads considering their [#BlackLivesMatter](https://nodejs.org/en/) update to the home page. Linking to their home page could be confusing to someone from our docs. Instead, we will link to the [About Page](https://nodejs.org/en/about/)