### PR TITLE
Add notes and link to page for FTS index creation

### DIFF
--- a/modules/howtos/pages/full-text-searching-index-creation.adoc
+++ b/modules/howtos/pages/full-text-searching-index-creation.adoc
@@ -1,0 +1,42 @@
+= FTS Index Creation
+:navtitle: Creating Indexes for Our Code Examples
+:page-topic-type: howto
+
+Before creating our FTS Indexes you will need the Sample Buckets installed
+
+.Travel Sample Hotel Description
+
+Inside the Couchbase Server Web UI, navigate to the *Search* page and click *Add Index*. Add the following values:
+
+Name: `travel-sample-hotel-description`
+Bucket: `travel-sample`
+
+For *Type Identifier* select the radio button next to *JSON type field* having a value: `type`. 
+
+Then we click *Add Type Mapping* entering the text `hotel` after the hash symbol (*#*) and selecting *inherit* from the dropdown and hit *ok*. This dropdown selection inherits a *Default Analyzer*.
+
+Next, Hover over the *hotel* type mapping we just created and click the "*+*" button and select *Insert Child Field*. 
+
+Our fields will have these values:
+
+field: `description` +
+type: `text` +
+searchable as: `description` +
+analyzer: `inherit` +
+
+We can select all of the checkboxes at the bottom of the form.
+
+Unchecked the *default* Type mapping as we don't want to scan all types.
+
+Select *Create Index* to finalize our changes.
+
+.Index Brewery by Date Range
+
+Inside the Couchbase Server Web UI, navigate to the *Search* page and click *Add Index*. Add the following values:
+
+Name: `index-brewery-by-daterange`
+Bucket: `beer-sample`
+
+We will use the *default* Type mapping for this index and scan all types as the bucket only has documents of type `brewery`.
+
+Select "Create Index" to finalize our changes.

--- a/modules/howtos/pages/full-text-searching-with-sdk.adoc
+++ b/modules/howtos/pages/full-text-searching-with-sdk.adoc
@@ -10,20 +10,23 @@ FTS allows you to create, manage, and query full-text indexes on JSON documents 
 
 It uses natural language processing for querying documents, provides relevance scoring on the results of your queries, and has fast indexes for querying a wide range of possible text searches.
 
-Supported query types include simple queries like Match and Term queries; range queries like Date Range and Numeric Range; and compound queries for conjunctions, disjunctions, and/or boolean queries.
+Search queries are executed at the cluster level and include simple text queries like Match and Term queries; range queries like Date Range and Numeric Range; and compound queries for conjunctions, disjunctions, and/or boolean queries.
 
 The Node.js SDK exposes an API for performing FTS queries which abstracts some of the complexity of using the underlying REST API.
 
-
-// As of Couchbase Server 6.5, FTS...
-
 == Examples
 
-Search queries are executed at the cluster level (not bucket or collection). All examples below will console log our returned documents along with their metadata and rows, each returned document has an index, id, score and sort value.
+Examples on this page are not copy pastable without having the related xref:6.5@server:manage:manage-settings/install-sample-buckets.adoc[Sample Buckets] installed and FTS indexes created. 
+
+We use the `travel-sample` dataset and `index-hotel-description` FTS index for all but one example. 
+
+The `beer-sample` dataset and `index-brewery-by-daterange` FTS index are used only for the Date Range example.
+
+xref:full-text-searching-index-creation.adoc[Setting up the FTS indexes]
 
 .Match
 
-Using the `travel-sample` xref:6.5@server:manage:manage-settings/install-sample-buckets.adoc[Sample Bucket], we define an FTS SearchQuery using the `match()` method to search for the specified term: `"five-star"`.
+Using the `travel-sample` xref:6.5@server:manage:manage-settings/install-sample-buckets.adoc[Sample Bucket], we define an FTS SearchQuery using the `match()` method to search for the specified term: `"five-star"`. 
 
 [source,javascript,indent=0]
 ----


### PR DESCRIPTION
The code samples on the FTS (Search) page of the documentation include two indexes that are used in conjunction with the `travel-sample` and `beer-sample` Sample Buckets.

We do not want to add lengthy step by step instructions with images etc. to this page, so I have updated the page to briefly talk about the requirements needed to get these code samples working locally and added a link to another page that covers the creation of the two FTS indexes used in the examples.

Pages updated in this PR:
- full-text-searching-with-sdk.adoc

Additional pages added and link to in this PR:
- full-text-searching-index-creation.adoc

I'm open to ideas of how to do this better. Do we need to create a navigation link to this additional page or just link to it from the Search (FTS) page? I have tested these changes locally and can preview them with Richard or Amarantha if needed via Zoom call.