### PR TITLE
nodejs example fix to expiry, and timeout units

### DIFF
--- a/modules/devguide/examples/nodejs/kv-operations.js
+++ b/modules/devguide/examples/nodejs/kv-operations.js
@@ -167,7 +167,7 @@ async function insertwithoptionsHandler(request, h) {
     try {
         // #tag::insertwithoptions[]
         const result = await collection.insert(key, document, 
-            {timeout:10000} // 10 seconds
+            {timeout:10} // 10 seconds
         );
         // #end::insertwithoptions[]
         cas = result.cas; // JSCBC-669?
@@ -184,7 +184,9 @@ async function replaceHandler(request, h) {
         // #tag::replace[]
         const result = await collection.replace(key,
             document, 
-            {cas:cas , expiration:60, timeout:5000}
+            {cas:cas,
+            expiry:60, // in seconds
+            timeout:5} // in seconds
         );
         // #end::replace[]
         cas = result.cas; // JSCBC-669?
@@ -200,10 +202,10 @@ async function durabilityHandler(request, h) {
     try {
         // #tag::durability[]
         let result = await collection.upsert(key, document,
-              {expiration:60,
+              {expiry:60, // in seconds
               persist_to:1,    
               replicate_to:0, // cannot replicate on single node
-              timeout:5000} 
+              timeout:5} // in seconds 
         );
         // #end::durability[]
         cas = result.cas; // JSCBC-669?
@@ -219,9 +221,9 @@ async function newdurabilityHandler(request, h) {
     try {
         // #tag::newdurability[]
         let result = await collection.upsert(key, document, 
-              {expiration:60,  // 60 seconds,
+              {expiry:60, // in seconds
               durabilityLevel:couchbase.DurabilityLevel.None, // Majority etc.
-              timeout:5000} // 5 seconds
+              timeout:5} // in seconds
         );
         // #end::newdurability[]
         cas = result.cas; // JSCBC-669?
@@ -243,7 +245,7 @@ async function removeHandler(request, h) {
             {cas:cas,
             persist_to:0,  // non-zero gives "not implemented"
             replicate_to:0, // cannot replicate on single node
-            timeout:5000}
+            timeout:5} // in seconds
         );
         // #end::remove[]
         return h.response(result);
@@ -272,8 +274,9 @@ async function touchwithoptionsHandler(request, h) {
     const key = request.query.k ? request.query.k : docKey;
     try {
         // #tag::touchwithoptions[]
-        const result = await collection.touch(key, 100,  // 100 seconds
-            {timeout:5000} // 5 seconds
+        const result = await collection.touch(key,
+            100, // expiry in seconds
+            {timeout:5} // 5 seconds
         );
         // #end::touchwithoptions[]
         return h.response(result);
@@ -297,7 +300,7 @@ async function incrementwithoptionsHandler(request, h) {
         // increment binary value by 1, if binValKey doesn’t exist, seed it at 1000
         const result = await collection.binary().increment(binValKey, 1,
             {initial:1000,
-            timeout:5000},
+            timeout:5}, // 5 seconds
           (err, res) => {
               console.log("res: " + JSON.stringify(res));
           });
@@ -330,7 +333,7 @@ async function decrementwithoptionsHandler(request, h) {
         // decrement binary value by 1, if binValKey doesn’t exist, seed it at 1000
         const result = await collection.binary().decrement(binValKey, 1,
             {initial:1000,
-            timeout:5000},
+            timeout:5}, // 5 seconds
         );
         // #end::decrementwithoptions[]
         return h.response(result);


### PR DESCRIPTION
I am not sure about this change, so it needs a closer sanity check...

Related, the nodejs SDK API reference docs doesn't describe the details of the mutation options, especially what are the time units...
https://docs.couchbase.com/sdk-api/couchbase-node-client/Collection.html#insert

From looking at the linked source code... https://docs.couchbase.com/sdk-api/couchbase-node-client/collection.js.html

1) It looks like the option field should be "expiry", not "expiration".

2) I am also guessing that the expiry units are seconds (could be wrong)?

3) And, the timeout units appear to instead to be seconds instead of milliseconds?