### PR TITLE
Fix secure connection example

### DIFF
--- a/modules/howtos/examples/auth.js
+++ b/modules/howtos/examples/auth.js
@@ -25,6 +25,8 @@ async function go() {
   // tag::tls-cacert[]
   const cluster = await couchbase.connect("couchbases://localhost", {
     trustStorePath: "/path/to/ca/certificates.pem",
+    username: "Administrator",
+    password: "password",
   });
   // end::tls-cacert[]
 

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -158,8 +158,9 @@ F4+FjEqAEIr1mQepDaNM0gEfVcgd2SzGhC3yhYFBAH//8W4DUot5ciEhoBs=
 -----END CERTIFICATE-----
 ----
 
-The next step is to enable encryption and pass it the path to the certificate file (note the connection string scheme:
-is `couchbases://` rather than the typical `couchbase://`). Additionally, you need to provide your `username` and `password`:
+The next step is to enable encryption and pass it the path to the certificate file 
+(note the connection string scheme is `couchbases://` rather than the non-TLS `couchbase://`). 
+Additionally, you need to provide your `username` and `password`:
 
 [source,javascript]
 ----

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -159,7 +159,7 @@ F4+FjEqAEIr1mQepDaNM0gEfVcgd2SzGhC3yhYFBAH//8W4DUot5ciEhoBs=
 ----
 
 The next step is to enable encryption and pass it the path to the certificate file (note the connection string scheme:
-is `couchbases://` rather than the typical `couchbase://`):
+is `couchbases://` rather than the typical `couchbase://`). Additionally, you need to provide your `username` and `password`:
 
 [source,javascript]
 ----


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-7747

This fixes the example code snippet for making a secure connection:
<img width="824" alt="Screen Shot 2020-12-08 at 12 15 04 PM" src="https://user-images.githubusercontent.com/13270204/101482789-1ad07200-394f-11eb-858d-a129226cd15d.png">
