### PR TITLE
DOC-7628 names scope/collection examples for NodeJS

### DIFF
--- a/modules/devguide/examples/nodejs/n1ql-queries-scoped.js
+++ b/modules/devguide/examples/nodejs/n1ql-queries-scoped.js
@@ -1,0 +1,34 @@
+var couchbase = require('couchbase');
+
+const cluster = new couchbase.Cluster(
+  'couchbase://localhost',
+  { username: 'Administrator', password: 'password' }
+)
+const bucket = cluster.bucket("travel-sample");
+
+
+async function start() {
+  console.log('start')
+}
+
+// #tag::queryscope[]
+const scope = bucket.scope("inventory");
+
+async function queryScope() {
+  const query = `
+    SELECT airportname, city FROM airport
+    WHERE city='San Jose'
+  `;
+
+  try {
+    let result = await scope.query(query)
+    console.log("Result:", result)
+    return result
+  } catch (error) {
+    console.error('Query failed: ', error)
+  }
+}
+// #end::queryscope[]
+
+start()
+  .then(queryScope)

--- a/modules/howtos/examples/analytics.js
+++ b/modules/howtos/examples/analytics.js
@@ -1,5 +1,11 @@
 "use strict";
 
+// NB: To run this file you will need:
+//    1) the travel-sample sample bucket loaded.
+//    2) an analytics node in the cluster
+//    3) a Dataset created in Analytics:
+//          CREATE DATASET airports ON `travel-sample` where `type` = 'airport';
+
 const couchbase = require("couchbase");
 
 async function go() {
@@ -13,41 +19,53 @@ async function go() {
 
   // tag::basic-query[]
   var result = await cluster.analyticsQuery('SELECT "hello" AS greeting');
-
   result.rows.forEach((row) => {
-    console.log(row.greeting);
+    console.log(row);
   });
   // end::basic-query[]
+  console.log();
+
+  function logResult (result) {
+    result.rows.forEach((row) => {
+      console.log(row);
+    });
+    console.log();
+  }
 
   // tag::simple-query[]
   var result = await cluster.analyticsQuery(
-    'SELECT airportname, country FROM airports WHERE country="France"'
+    'SELECT airportname, country FROM airports WHERE country="France" LIMIT 3'
   );
   // end::simple-query[]
+  logResult(result);
 
   // tag::posparam-query[]
   var result = await cluster.analyticsQuery(
-    "SELECT airportname, country FROM airports WHERE country = ?",
-    ["France"]
+    "SELECT airportname, country FROM airports WHERE country = ? LIMIT 3",
+    { parameters: ["France"] }
   );
   // end::posparam-query[]
+  logResult(result);
 
   // tag::namedparam-query[]
   var result = await cluster.analyticsQuery(
-    "SELECT airportname, country FROM airports WHERE country = $country",
-    { country: "France" }
+    "SELECT airportname, country FROM airports WHERE country = $country LIMIT 3",
+   { parameters:
+      { country: "France" } }
   );
   // end::namedparam-query[]
+  logResult(result);
 
   // tag::priority-query[]
   var result = await cluster.analyticsQuery(
-    'SELECT airportname, country FROM airports WHERE country="France"',
+    'SELECT airportname, country FROM airports WHERE country="France" LIMIT 3',
     {
       priority: true,
       timeout: 100, // seconds
     }
   );
   // end::priority-query[]
+  logResult(result);
 
   // tag::handle-rows[]
   var result = await cluster.analyticsQuery('SELECT "hello" AS greeting');
@@ -56,9 +74,10 @@ async function go() {
     console.log("Greeting: %s", row.greeting);
   });
   // end::handle-rows[]
+  console.log();
 
   // tag::handle-meta[]
-  var result = await cluster.queryAnalytics('SELECT "hello" AS greeting');
+  var result = await cluster.analyticsQuery('SELECT "hello" AS greeting');
 
   console.log("Elapsed time: %d", result.meta.metrics.elapsedTime);
   console.log("Execution time: %d", result.meta.metrics.executionTime);
@@ -68,4 +87,5 @@ async function go() {
 }
 go()
   .then((res) => console.log("DONE:", res))
-  .catch((err) => console.error("ERR:", err));
+  .catch((err) => console.error("ERR:", err))
+  .then(process.exit)

--- a/modules/howtos/examples/analytics.js
+++ b/modules/howtos/examples/analytics.js
@@ -5,6 +5,8 @@
 //    2) an analytics node in the cluster
 //    3) a Dataset created in Analytics:
 //          CREATE DATASET airports ON `travel-sample` where `type` = 'airport';
+//    4) a Dataset on a collection:
+//          CREATE DATASET `airports-collection` ON `travel-sample`.inventory.airport;
 
 const couchbase = require("couchbase");
 
@@ -84,6 +86,17 @@ async function go() {
   console.log("Result count: %d", result.meta.metrics.resultCount);
   console.log("Error count: %d", result.meta.metrics.errorCount);
   // end::handle-meta[]
+
+  // tag::handle-collection[]
+  var result = await cluster.analyticsQuery('SELECT airportname, country FROM `airports-collection` WHERE country="France" LIMIT 3');
+  // end::handle-collection[]
+  logResult(result);
+
+  // // tag::handle-scope[]
+  // var scope = bucket.scope("inventory");
+  // var result = await scope.analyticsQuery('SELECT airportname, country FROM `airports-collection` WHERE country="France" LIMIT 3');
+  // // end::handle-scope[]
+  // logResult(result);
 }
 go()
   .then((res) => console.log("DONE:", res))

--- a/modules/howtos/pages/analytics-using-sdk.adoc
+++ b/modules/howtos/pages/analytics-using-sdk.adoc
@@ -106,6 +106,31 @@ include::../examples/analytics.js[tag=handle-meta]
 For a listing of available `metrics` in the meta-data, see the xref:concept-docs:analytics-for-sdk-users.adoc[Understanding Analytics] SDK doc.
 
 
+== Scoped Queries on Named Collections
+
+Given a dataset created against a collection, for example:
+
+[source,n1ql]
+----
+CREATE DATASET `airports-collection` ON `travel-sample`.inventory.airport;
+----
+
+You can run a query as follows:
+
+[source,javascript]
+----
+include::../examples/analytics.js[tag=handle-collection]
+----
+
+// // The following is pending a query JSCBC-846
+// In addition to running a query via the `Cluster` object, you can run one via the `Scope` object.
+
+// [source,javascript]
+// ----
+// include::../examples/analytics.js[tag=handle-scope]
+// ----
+
+
 == Advanced Analytics Topics
 
 From Couchbase Data Platform 6.5, _Deferred Queries_ and _KV Ingestion_ are added to CBAS.

--- a/modules/howtos/pages/n1ql-queries-with-sdk.adoc
+++ b/modules/howtos/pages/n1ql-queries-with-sdk.adoc
@@ -139,6 +139,12 @@ It takes the statement as a required argument, and then allows additional option
 CAUTION: This feature is marked xref:project-docs:compatibility.adoc#interface-stability[_Uncommitted_].
 Expect a promotion to _Committed_ API in a future release.
 
+Here, we query the `inventory` scope for the `airport` collection:
+[source,javascript]
+----
+include::devguide:example$nodejs/n1ql-queries-scoped.js[tag=queryscope,indent=0]
+----
+
 See the https://docs.couchbase.com/sdk-api/couchbase-node-client/Scope.html#query[API docs] for more information.
 
 


### PR DESCRIPTION
Code examples included both for plain query and analyticsQuery.
All code run and working.

NB: Scoped analyticsQuery example doesn't work, pending clarification/fix in JSCBC-846 so this part is implemented in docs but commented out, and will need to be uncommented and corrected.