### PR TITLE
DOC-9032 - Update compat tables and feature matrix for 7.0 GA

### DIFF
--- a/modules/project-docs/pages/compatibility.adoc
+++ b/modules/project-docs/pages/compatibility.adoc
@@ -100,7 +100,7 @@ The 3.1 Node.js SDK is compatible with https://ottomanjs.com/#introduction[versi
 [.table-merge-cells]
 [cols="7,7,5,6,5"]
 |===
-| | Server 5.0, 5.1, & 5.5 | Server 6.0 | Server 6.5 & 6.6 | Server 7.0β
+| | Server 5.0, 5.1, & 5.5 | Server 6.0 | Server 6.5 & 6.6 | Server 7.0
 
 | Enhanced Durability
 4+| All SDK versions
@@ -120,7 +120,7 @@ The 3.1 Node.js SDK is compatible with https://ottomanjs.com/#introduction[versi
 
 | Scope-Level N1QL Queries
 3+| Not Supported
-| Developer Preview in 7.0β, SDK 3.0.7
+| Since SDK 3.0.7
 |===
 
 include::6.6@sdk:shared:partial$network-requirements.adoc[]

--- a/modules/project-docs/pages/compatibility.adoc
+++ b/modules/project-docs/pages/compatibility.adoc
@@ -46,21 +46,12 @@ It is best to upgrade either the SDK or the Couchbase version you are using.
 | *✔*
 | *✔*
 
-| *Server 7.0β*
+| *Server 7.0*
 | *✖*
 | *✖*
 | *◎*
-| *◎* _(see below)_
+| *◎*
 |===
-
-[IMPORTANT]
-====
-An API change in the planned release version of Couchbase Server 7.0 means changes in the latest versions of the SDK which render these new SDK versions incompatible with the beta versions of 7.0.
-
-Node.js SDK *3.1.2* is the latest version compatible with Server 7.0β.
-
-Later SDK 3.1.x releases will be limited to the Default Scope and Collection with the beta 7.0 server, and will only be fully compatible with the full release version.
-====
 
 Note the https://www.couchbase.com/support-policy[End of Life dates^] for Couchbase Server and SDK versions.
 See the notes there for Support details.


### PR DESCRIPTION
Figured I could also update the `Feature Matrix` and remove any mention of 7.0 *beta* and *DP*, but please let me know if I should change anything else in there.