### PR TITLE
(SDK 2.6) Update compatibility table for 7.0 GA

### DIFF
--- a/modules/ROOT/pages/compatibility-versions-features.adoc
+++ b/modules/ROOT/pages/compatibility-versions-features.adoc
@@ -22,18 +22,6 @@ It is best to upgrade either the SDK or the Couchbase version you are using.
 |===
 | | SDK 2.2, 2.3 | SDK 2.4 | SDK 2.5 | SDK 2.6
 
-| *Server 4.0-4.5*
-| ◎
-| *✔*
-| *✔*
-| *✔*
-
-| *Server 4.6*
-| ◎
-| *✔*
-| *✔*
-| *✔*
-
 | *Server 5.0-5.5*
 | ◎
 | *✔*
@@ -51,6 +39,12 @@ It is best to upgrade either the SDK or the Couchbase version you are using.
 | *✖*
 | *✖*
 | *✔*
+
+| *Server 7.0*
+| *✖*
+| *✖*
+| *✖*
+| ◎
 |===
 
 Note the https://www.couchbase.com/support-policy[End of Life dates^] for Couchbase Server and SDK versions.


### PR DESCRIPTION
Adds Server 7.0 to compat table and removes 4.0 - 4.6 versions since they are no longer supported (EOL): 
https://www.couchbase.com/support-policy/enterprise-software