### PR TITLE
Ensure start using guide code snipppets are complete

### DIFF
--- a/modules/hello-world/examples/start-using.js
+++ b/modules/hello-world/examples/start-using.js
@@ -37,7 +37,6 @@ async function main() {
   // end::test-doc[]
 
   // tag::upsert-func[]
-  // upsert document function
   const upsertDocument = async (doc) => {
     try {
       // key will equal: "airline_8091"
@@ -52,12 +51,10 @@ async function main() {
   // end::upsert-func[]
 
   // tag::upsert-invoke[]
-  // call upsert document function
   await upsertDocument(airline)
   // end::upsert-invoke[]
 
   // tag::get-func[]
-  // get document function
   const getAirlineByKey = async (key) => {
     try {
       const result = await collection.get(key)
@@ -70,7 +67,6 @@ async function main() {
   // end::get-func[]
 
   // tag::get-invoke[]
-  // call get document function
   await getAirlineByKey('airline_8091')
 }
 // end::get-invoke[]

--- a/modules/hello-world/examples/start-using.js
+++ b/modules/hello-world/examples/start-using.js
@@ -37,6 +37,7 @@ async function main() {
   // end::test-doc[]
 
   // tag::upsert-func[]
+  // upsert document function
   const upsertDocument = async (doc) => {
     try {
       // key will equal: "airline_8091"
@@ -51,6 +52,7 @@ async function main() {
   // end::upsert-func[]
 
   // tag::upsert-invoke[]
+  // call upsert document function
   await upsertDocument(airline)
   // end::upsert-invoke[]
 

--- a/modules/hello-world/examples/start-using.js
+++ b/modules/hello-world/examples/start-using.js
@@ -1,79 +1,79 @@
-"use strict";
+'use strict'
 
 // tag::connect[]
-const couchbase = require("couchbase");
+const couchbase = require('couchbase')
 
 async function main() {
-  const cluster = await couchbase.connect("couchbase://localhost", {
-    username: "Administrator",
-    password: "password",
-  });
+  const cluster = await couchbase.connect('couchbase://localhost', {
+    username: 'Administrator',
+    password: 'password',
+  })
   // end::connect[]
 
   // tag::bucket[]
   // get a reference to our bucket
-  const bucket = cluster.bucket("travel-sample");
+  const bucket = cluster.bucket('travel-sample')
   // end::bucket[]
 
   // tag::collection[]
   // get a reference to a collection
-  const collection = bucket.scope("inventory").collection("airline");
+  const collection = bucket.scope('inventory').collection('airline')
   // end::collection[]
 
   // tag::default-collection[]
   // get a reference to the default collection, required for older Couchbase server versions
-  const collection_default = bucket.defaultCollection();
+  const collection_default = bucket.defaultCollection()
   // end::default-collection[]
 
   // tag::test-doc[]
   const airline = {
-    type: "airline",
+    type: 'airline',
     id: 8091,
-    callsign: "CBS",
+    callsign: 'CBS',
     iata: null,
     icao: null,
-    name: "Couchbase Airways",
-  };
+    name: 'Couchbase Airways',
+  }
   // end::test-doc[]
 
   // tag::upsert-func[]
   const upsertDocument = async (doc) => {
     try {
       // key will equal: "airline_8091"
-      const key = `${doc.type}_${doc.id}`;
-      const result = await collection.upsert(key, doc);
-      console.log("Upsert Result: ");
-      console.log(result);
+      const key = `${doc.type}_${doc.id}`
+      const result = await collection.upsert(key, doc)
+      console.log('Upsert Result: ')
+      console.log(result)
     } catch (error) {
-      console.error(error);
+      console.error(error)
     }
-  };
+  }
   // end::upsert-func[]
 
   // tag::upsert-invoke[]
-  await upsertDocument(airline);
+  await upsertDocument(airline)
   // end::upsert-invoke[]
 
   // tag::get-func[]
   // get document function
   const getAirlineByKey = async (key) => {
     try {
-      const result = await collection.get(key);
-      console.log("Get Result: ");
-      console.log(result);
+      const result = await collection.get(key)
+      console.log('Get Result: ')
+      console.log(result)
     } catch (error) {
-      console.error(error);
+      console.error(error)
     }
-  };
+  }
   // end::get-func[]
-
 
   // tag::get-invoke[]
   // call get document function
-  await getAirlineByKey("airline_8091");
-  // end::get-invoke[]
-
-  console.log("END");
+  await getAirlineByKey('airline_8091')
 }
+// end::get-invoke[]
 
-main().then(process.exit);
+// tag::run-main[]
+// Run the main function
+main().then(process.exit)
+// end::run-main[]

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -124,7 +124,7 @@ include::../examples/start-using.js[tag=get-func]
 
 KV Operations are described in detail on the xref:howtos:kv-operations.adoc[KV Operations page].
 
-Now, we can simply call the `getAirlineByKey` function passing in our valid document key `airline_8091`:
+Now, we can simply call the `getAirlineByKey` function passing in our valid document key `airline_8091` and close our `main` function:
 
 [source,javascript,indent=0]
 ----
@@ -172,10 +172,35 @@ GetResult {
 ----
 
 
-== Cloud Connections
+== Full Example
 
-For developing on Couchbase Cloud,
-try the https://github.com/couchbase/docs-sdk-nodejs/blob/release/3.2/modules/devguide/examples/nodejs/cloud.js[Cloud-based Hello World program],
+If you want to copy and paste to run the full example, here it is:
+
+[{tabs}] 
+==== 
+Local Couchbase Server::
++ 
+-- 
+[source,javascript,indent=0]
+----
+include::../examples/start-using.js[tags=**]
+----
+--
+
+Couchbase Cloud Sample::
++
+--
+If you are connecting to https://docs.couchbase.com/cloud/index.html[Couchbase Cloud], be sure to get the correct endpoint as well as user, password, and `couchbasecloudbucket`  -- and see the <<cloud-connections, Cloud section>>, below.
+
+[source,javascript]
+----
+include::devguide:example$nodejs/cloud.js[tags=**]
+----
+--
+====
+
+
+== Cloud Connections
 
 If you are not working from the same _Availability Zone_ as your Couchbase Cloud, refer to the following:
 

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -131,6 +131,13 @@ Now, we can simply call the `getAirlineByKey` function passing in our valid docu
 include::../examples/start-using.js[tag=get-invoke]
 ----
 
+To ensure that we can run the main function, we add this last line of code:
+
+[source,javascript,indent=0]
+----
+include::../examples/start-using.js[tag=run-main]
+----
+
 Now we can run our code using the following command:
 
 [source,bash]
@@ -142,24 +149,25 @@ The results you should expect are as follows:
 
 [source,bash]
 ----
-Upsert Result:
-{
-  cas: CbCas { '0': <Buffer 00 00 13 13 f4 32 10 16> },
+Upsert Result: 
+MutationResult {
+  cas: CbCas { '0': <Buffer 00 00 3e b7 72 65 a0 16> },
   token: CbMutationToken {
-    '0': <Buffer cc 6d 45 09 c2 ce 00 00 2c 00 00 00 00 00 00 00 a9 03 00 00 00 00 00 00 74 72 61 76 65 6c 2d 73 61 6d 70 6c 65 00 00 00 50 6b bf ef fe 7f 00 00 28 2e ... 230 more bytes>
+    '0': <Buffer bf 02 e0 23 a7 4d 00 00 58 00 00 00 00 00 00 00 a9 03 00 00 00 00 00 00 74 72 61 76 65 6c 2d 73 61 6d 70 6c 65 00 00 00 48 54 83 05 01 00 00 00 30 54 ... 230 more bytes>
   }
 }
-Get Result:
-{
-  cas: CbCas { '0': <Buffer 00 00 13 13 f4 32 10 16> },
-  value: {
+Get Result: 
+GetResult {
+  content: {
     type: 'airline',
     id: 8091,
     callsign: 'CBS',
     iata: null,
     icao: null,
     name: 'Couchbase Airways'
-  }
+  },
+  cas: CbCas { '0': <Buffer 00 00 3e b7 72 65 a0 16> },
+  expiryTime: undefined
 }
 ----
 


### PR DESCRIPTION
Ensures that if a user follows the getting started guide step by step they will have a working example at the end when we ask them to run it.

Also note that the code has been formatted based on the `.prettierrc` formatting config Brett added:
```
{
  "semi": false,
  "arrowParens": "always",
  "singleQuote": true,
  "trailingComma": "es5"
}
```