### PR TITLE
DOC-9449 - Point to modules page in Node.js API doc

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -58,7 +58,7 @@
 ** xref:concept-docs:rbac.adoc[RBAC]
 
 .References
-* https://docs.couchbase.com/sdk-api/couchbase-node-client[API Reference]
+* https://docs.couchbase.com/sdk-api/couchbase-node-client/modules.html[API Reference]
 * xref:ref:client-settings.adoc[Client Settings]
 // * xref:ref:data-structures[Data Structures]
 * xref:ref:error-codes.adoc[Error Messages]

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -425,7 +425,7 @@ If you are not working from the same _Availability Zone_ as your Capella instanc
 
 == Additional Resources
 
-The API reference is generated for each release and the latest can be found http://docs.couchbase.com/sdk-api/couchbase-node-client/[here].
+The API reference is generated for each release and the latest can be found https://docs.couchbase.com/sdk-api/couchbase-node-client/modules.html[here].
 
 Links to each release are to be found in the xref:project-docs:sdk-release-notes.adoc[individual release notes].
 

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -35,7 +35,7 @@ Version 3.2.2 is the next minor release of the third generation Node.js SDK, bri
 $ npm install couchbase@3.2.2
 ----
 
-http://docs.couchbase.com/sdk-api/couchbase-node-client-3.2.2/[API Reference]
+https://docs.couchbase.com/sdk-api/couchbase-node-client-3.2.2/modules.html[API Reference]
 
 === New Features
 
@@ -72,7 +72,7 @@ Version 3.2.1 is the next minor release of the third generation Node.js SDK, bri
 $ npm install couchbase@3.2.1
 ----
 
-http://docs.couchbase.com/sdk-api/couchbase-node-client-3.2.1/[API Reference]
+https://docs.couchbase.com/sdk-api/couchbase-node-client-3.2.1/modules.html[API Reference]
 
 === New Features
 
@@ -107,7 +107,7 @@ Version 3.2.0 is the next minor release of the third generation Node.js SDK, bri
 $ npm install couchbase@3.2.0
 ----
 
-http://docs.couchbase.com/sdk-api/couchbase-node-client-3.2.0/[API Reference]
+https://docs.couchbase.com/sdk-api/couchbase-node-client-3.2.0/modules.html[API Reference]
 
 === New Features
 


### PR DESCRIPTION
Also added in landing page on docs-site in this [PR](https://github.com/couchbase/docs-site/pull/443)