### PR TITLE
DOC-9236 - Add missing example for mutateIn upsert/insert options

### DIFF
--- a/modules/howtos/examples/subdoc.js
+++ b/modules/howtos/examples/subdoc.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const couchbase = require('couchbase')
+const { StoreSemantics } = couchbase
 
 async function go() {
   const cluster = await couchbase.connect('couchbase://localhost', {
@@ -224,6 +225,29 @@ async function go() {
     ),
   ])
   // end::mutate-upsert-parents[]
+
+  console.log('mutate-store-semantics')
+  // tag::mutate-store-semantics[]
+  try {
+    // Mutate fields in a document that may or may not exist.
+    await collection.mutateIn(
+      'alice-123',
+      [
+        couchbase.MutateInSpec.insert('name', 'Alice'),
+        couchbase.MutateInSpec.upsert('email', 'alice@test.com'),
+      ],
+      {
+        storeSemantics: StoreSemantics.Upsert,
+      }
+    )
+  } catch (e) {
+    if (e instanceof couchbase.PathExistsError) {
+      console.log('Path already exists, not adding unique value')
+    } else {
+      throw e
+    }
+  }
+  // end::mutate-store-semantics[]
 
   console.log('mutate-cas')
   const SOME_ID = '100'

--- a/modules/howtos/examples/subdoc.js
+++ b/modules/howtos/examples/subdoc.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const couchbase = require('couchbase')
-const { StoreSemantics } = couchbase
 
 async function go() {
   const cluster = await couchbase.connect('couchbase://localhost', {
@@ -237,7 +236,7 @@ async function go() {
         couchbase.MutateInSpec.upsert('email', 'alice@test.com'),
       ],
       {
-        storeSemantics: StoreSemantics.Upsert,
+        storeSemantics: couchbase.StoreSemantics.Upsert,
       }
     )
   } catch (e) {

--- a/modules/howtos/pages/subdocument-operations.adoc
+++ b/modules/howtos/pages/subdocument-operations.adoc
@@ -114,6 +114,16 @@ Here's an example of one which replaces one path and removes another.
 include::../examples/subdoc.js[tag=mutate-multi]
 ----
 
+.Mutate with store semantics
+The `storeSemantics` option can be used to define the document storage semantics for a _mutate-in_ operation.
+In this particular example we use the `Upsert` semantic, which means the document will be updated if it exists, and created if it doesn't. 
+Note that when a document is updated, only the specified paths will be modified.
+
+[source,javascript,indent=0]
+----
+include::../examples/subdoc.js[tag=mutate-store-semantics]
+----
+
 NOTE: `mutateIn` is an _atomic_ operation.
 If any single `ops` fails, then the entire document is left unchanged.
 

--- a/modules/howtos/pages/subdocument-operations.adoc
+++ b/modules/howtos/pages/subdocument-operations.adoc
@@ -116,7 +116,7 @@ include::../examples/subdoc.js[tag=mutate-multi]
 
 .Mutate with store semantics
 The `storeSemantics` option can be used to define the document storage semantics for a _mutate-in_ operation.
-In this particular example we use the `Upsert` semantic, which means the document will be updated if it exists, and created if it doesn't. 
+In this particular example we use the `Upsert` semantics, which means the document will be updated if it exists, and created if it doesn't. 
 Note that when a document is updated, only the specified paths will be modified.
 
 [source,javascript,indent=0]


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-9236 

Adds a new example that uses the `storageSemantics` option for a `mutateIn` operation, which seems to have replaced `upsertDocument `.
We didn't document this before, so not sure if I should mention the deprecation of  the `upsertDocument` option.

Probably worth updating this in the 2.6 docs I guess, though 2.6 EOL seems to be March 2022.
https://www.couchbase.com/support-policy/enterprise-software