### PR TITLE
fix import test

### DIFF
--- a/modules/howtos/examples/import.js
+++ b/modules/howtos/examples/import.js
@@ -98,12 +98,12 @@ async function main() {
   const path_to_import_json = `${__dirname}/import.json`
   const path_to_import_jsonl = `${__dirname}/import.jsonl`
   
-  importStream(csvStream(path_to_import_csv))
-  importStream(tsvStream(path_to_import_tsv ))
-  importStream(jsonStream(path_to_import_json))
-  importStream(jsonlStream(path_to_import_jsonl))
+  await importStream(csvStream(path_to_import_csv))
+  await importStream(tsvStream(path_to_import_tsv ))
+  await importStream(jsonStream(path_to_import_json))
+  await importStream(jsonlStream(path_to_import_jsonl))
     
 }
 
 
-main()
+main().then(process.exit)


### PR DESCRIPTION
need to await, and exit the process

(unsure why I need this, as the file ran under `node` fine, but not when run in `bats`.
In theory the `process.exit` should also be unneeded.)