### PR TITLE
Correct cluster.close reference

### DIFF
--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -73,7 +73,7 @@ If you wish to use TLS, the connection string must be configured as described in
 We recommend creating a single `Cluster` instance when your application starts up, and sharing this instance throughout your application.
 Each of the respective sub-instances (Bucket, Collection, etc...) of the Cluster class can be stored and re-used, or created in an on-demand fashion whenever needed.
 
-Before your application stops, gracefully shut down the client by calling the `disconnect()` method of each `Cluster` you created.
+Before your application stops, gracefully shut down the client by calling the `close()` method of each `Cluster` you created.
 
 
 == Alternate Addresses and Custom Ports


### PR DESCRIPTION
The documentation referenced a disconnect() function on Clusters, which does not exist. The correct function name is close(), as seen here: https://github.com/couchbase/couchnode/blob/d9964c677e402bbf7f4eb15c1ba2b6ce03b8acff/lib/cluster.ts#L462

* Corrected function name