### PR TITLE
DOC-9609: More clean up of end tags, references.

### DIFF
--- a/modules/howtos/examples/transactions-example.ts
+++ b/modules/howtos/examples/transactions-example.ts
@@ -42,27 +42,25 @@ async function main() {
   const collection_default: Collection = bucket.defaultCollection()
   // end::ts-default-collection[]
 
-   // Set up for what we'll do below
-   await removeOrWarn("doc-a")
-   await removeOrWarn("doc-b")
-   await removeOrWarn("doc-c")
-   await removeOrWarn(testDoc)
-   await removeOrWarn("docId")
+  // Set up for what we'll do below
+  await removeOrWarn('doc-a')
+  await removeOrWarn('doc-b')
+  await removeOrWarn('doc-c')
+  await removeOrWarn(testDoc)
+  await removeOrWarn('docId')
 
   //  await collection.upsert("doc-a", {})
-   await collection.upsert("doc-b", {})
-   await collection.upsert("doc-c", {})
-   await collection.upsert("doc-id", {})
-   await collection.upsert("a-doc", {})
+  await collection.upsert('doc-b', {})
+  await collection.upsert('doc-c', {})
+  await collection.upsert('doc-id', {})
+  await collection.upsert('a-doc', {})
 
-
-
-  try { 
+  try {
     await cluster.transactions().run(async (attempt) => {
       await attempt.insert(collection, testDoc, 'hello')
     })
   } catch (error) {
-    console.log("failed to insert " + testDoc)
+    console.log('failed to insert ' + testDoc)
   }
 
   // tag::create[]
@@ -153,7 +151,7 @@ async function main() {
       // commit result was returned to the client
     }
   }
-  // tag::examples[]
+  // end::examples[]
 
   // execute other exmaples
   try {
@@ -410,7 +408,7 @@ async function querySingle() {
       // after the transactions operations completed and committed, but before the
       // commit result was returned to the client
     }
-  // end:querySingle[]
+  // end::querySingle[]
 }
 
 async function querySingleScoped() {
@@ -429,7 +427,7 @@ async function querySingleScoped() {
   // Bucket travelSample = cluster.bucket("travel-sample");
   // Scope inventory = travelSample.scope("inventory");
   // transactions.query(inventory, bulkLoadStatement);
-  // end:querySingleScoped[]
+  // // end::querySingleScoped[]
 }
 
 async function querySingleConfigured() {

--- a/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
+++ b/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
@@ -95,7 +95,8 @@ include::example$transactions-example.ts[tag=remove,indent=0]
 === Inserting
 
 [source,typescript]
-----include::example$transactions-example.js[tag=insert,indent=0]
+----
+include::example$transactions-example.js[tag=insert,indent=0]
 ----
 
 == Key-Value Reads
@@ -162,7 +163,7 @@ This example shows INSERTing a document and then SELECTing it again.
 
 [source,typescript]
 ----
-include::example$Ttransactions-example.ts[tag=queryInsert,indent=0]
+include::example$transactions-example.ts[tag=queryInsert,indent=0]
 ----
 <1> The inserted document is only staged at this point. as the transaction has not yet committed.
 Other transactions, and other non-transactional actors, will not be able to see this staged insert yet.
@@ -184,7 +185,7 @@ Query options can be provided via `TransactionsQueryOptions`, which provides a s
 
 [source,typescript]
 ----
-include::example$Ttransactions-example.ts[tag=queryOptions,indent=0]
+include::example$transactions-example.ts[tag=queryOptions,indent=0]
 ----
 
 // TODO: check this partial to see if it matches up across SDKs.  otherwise, make it a table?
@@ -202,19 +203,19 @@ include::7.1@sdk:shared:partial$acid-transactions.adoc[tag=query-single]
 include::example$transactions-example.ts[tag=querySingle,indent=0]
 ----
 
-You can also run a single query transaction against a particular `Scope` (these examples will exclude the full error handling for brevity):
-
-[source,typescript]
-----
-include::example$transactions-example.ts[tag=querySingleScoped,indent=0]
-----
-
-and configure it:
-
-[source,typescript]
-----
-include::example$transactions-example.ts[tag=querySingleConfigured,indent=0]
-----
+// You can also run a single query transaction against a particular `Scope` (these examples will exclude the full error handling for brevity):
+//
+// [source,typescript]
+// ----
+// include::example$transactions-example.ts[tag=querySingleScoped,indent=0]
+// ----
+//
+// and configure it:
+//
+// [source,typescript]
+// ----
+// include::example$transactions-example.ts[tag=querySingleConfigured,indent=0]
+// ----
 
 == Committing
 


### PR DESCRIPTION
Looked at the staging, and I see a few missing ":" and typos threw off some of the example blocks.