### PR TITLE
DOC-9723: Couchbase++ Client Settings admonitions

### DIFF
--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -42,7 +42,8 @@ The client fetches the full address list from the first node it is able to conta
 [#connection-strings]
 == Connection Strings
 
-WARNING: the backend implementation of connection strings parameters changed substantially in 4.0 and is not currently fully documented. This will be resolved in a future 4.x release.
+WARNING: The backend implementation of connection strings parameters changed substantially in 4.0 and is not currently fully documented.
+This will be resolved in a future 4.x release.
 See xref:project-docs:migrating-sdk-code-to-3.n.adoc#sdk4-specifics[more details on migrating to 4.0].
 
 A Couchbase connection string is a comma-delimited list of IP addresses and/or hostnames, optionally followed by a list of parameters.

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -42,6 +42,9 @@ The client fetches the full address list from the first node it is able to conta
 [#connection-strings]
 == Connection Strings
 
+WARNING: the backend implementation of connection strings parameters changed substantially in 4.0 and is not currently fully documented. This will be resolved in a future 4.x release.
+See xref:project-docs:migrating-sdk-code-to-3.n.adoc#sdk4-specifics[more details on migrating to 4.0].
+
 A Couchbase connection string is a comma-delimited list of IP addresses and/or hostnames, optionally followed by a list of parameters.
 
 The parameter list is just like the query component of a URI; name-value pairs have an equals sign (`=`) separating the name and value, with an ampersand (`&`) between each pair.

--- a/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
+++ b/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
@@ -535,10 +535,12 @@ They are available in 3.2, and will be available in a later 4.x release.
 * xref:concept-docs:response-time-observability.adoc[Response Time Availability]
 * xref:concept-docs:durability-replication-failure-considerations.adoc#older-server-versions[Legacy durability]
 * Log forwarding
-* Replica reads 
+* Replica reads
 
 In addition:
 
 * The required minimum version of Node.js is now v12 (the oldest supported maintenance LTS release).
 * Ping error entries are now typed.
 * `get` requests on locked documents now retry rather than fast-fail.
+* The changes to xref:ref:client-settings.adoc[Client Settings] are not currently documented.
+* The changes to xref:howtos:managing-connections.adoc#connection-strings[Connection Strings] are not currently documented.

--- a/modules/ref/pages/client-settings.adoc
+++ b/modules/ref/pages/client-settings.adoc
@@ -9,7 +9,8 @@ include::project-docs:partial$attributes.adoc[]
 [abstract]
 {description}
 
-WARNING: the backend implementation of client settings changed substantially in 4.0 and is not currently fully documented. This will be resolved in a future 4.x release.
+WARNING: The backend implementation of client settings changed substantially in 4.0 and is not currently fully documented.
+This will be resolved in a future 4.x release.
 See xref:project-docs:migrating-sdk-code-to-3.n.adoc#sdk4-specifics[more details on migrating to 4.0].
 
 Some details from the old `libcouchbase`

--- a/modules/ref/pages/client-settings.adoc
+++ b/modules/ref/pages/client-settings.adoc
@@ -9,10 +9,11 @@ include::project-docs:partial$attributes.adoc[]
 [abstract]
 {description}
 
-Beyond the connection string, most settings are changed by calls to the libcouchbase API
-(implemented with Couchbase++ from Node.js SDK 4.0) --
-refer to the https://docs.couchbase.com/sdk-api/couchbase-c-client/group\__lcb-cntl.html[API doc on `lcb_cntl()`]
-and the https://docs.couchbase.com/sdk-api/couchbase-c-client/group__lcb-cntl-settings.html[settings list].
+WARNING: the backend implementation of client settings changed substantially in 4.0 and is not currently fully documented. This will be resolved in a future 4.x release.
+See xref:project-docs:migrating-sdk-code-to-3.n.adoc#sdk4-specifics[more details on migrating to 4.0].
+
+Some details from the old `libcouchbase`
+https://docs.couchbase.com/sdk-api/couchbase-c-client/group__lcb-cntl-settings.html[settings list] may be useful for reference.
 
 // == Timeout Options
 


### PR DESCRIPTION
While parts of Couchbase++ use in Node.js are still in flux, we do need to
mention this.