### PR TITLE
add release notes for ottoman v2.2.0

### DIFF
--- a/modules/project-docs/pages/ottoman-release-notes.adoc
+++ b/modules/project-docs/pages/ottoman-release-notes.adoc
@@ -22,7 +22,8 @@ please read the xref:3.2@nodejs-sdk:hello-world:start-using-ottoman.adoc[Ottoman
 
 == Version 2.2.0 (29 March 2022)
 
-Version 2.2.0 is a minor release of Ottoman. This release adds two new features, and a number of dependency upgrades.
+Version 2.2.0 is a minor release of the Ottoman ODM. 
+This release adds two new features, and a number of dependency upgrades.
 
 [source,console]
 ----

--- a/modules/project-docs/pages/ottoman-release-notes.adoc
+++ b/modules/project-docs/pages/ottoman-release-notes.adoc
@@ -20,6 +20,23 @@ We intend to fully support it with the next 4.1 release.
 In the meantime, if you are interested in checking out Ottoman, 
 please read the xref:3.2@nodejs-sdk:hello-world:start-using-ottoman.adoc[Ottoman for Node.js SDK 3.2] page.
 
+== Version 2.2.0 (29 March 2022)
+
+Version 2.2.0 is a minor release of Ottoman. This release adds two new features, and a number of dependency upgrades.
+
+[source,console]
+----
+$ npm install ottoman@2.2.0
+----
+
+https://ottomanjs.com/#installation[Ottoman installation]
+
+=== New Features
+
+* Ottoman: added support to allow `modelKey` to be a nested field.
+
+* Hooks: trigger embed schema hooks.
+
 
 == Version 2.1.0 (7 Feb 2022)
 


### PR DESCRIPTION
- updated release notes with the latest 2.2.0 release, based on the [auto-generated changelog](https://github.com/couchbaselabs/node-ottoman/blob/master/CHANGELOG.md)