### PR TITLE
DOC-10081 - Temp fix for running examples with try-it-now

### DIFF
--- a/modules/devguide/examples/nodejs/cloud.js
+++ b/modules/devguide/examples/nodejs/cloud.js
@@ -55,9 +55,9 @@ async function main() {
   // tag::query[]
   // Perform a N1QL Query
   const queryResult = await bucket
-    .scope('tenant_agent_00')
-    .query('SELECT name FROM `users` WHERE $1 in interests', {
-      parameters: ['Swimming'],
+    .scope('inventory')
+    .query('SELECT name FROM `airline` WHERE country=$1 LIMIT 10', {
+      parameters: ['United States'],
     })
   console.log('Query Results:')
   queryResult.rows.forEach((row) => {

--- a/modules/hello-world/examples/cloud.ts
+++ b/modules/hello-world/examples/cloud.ts
@@ -73,9 +73,9 @@ async function main() {
   // tag::ts-query[]
   // Perform a N1QL Query
   const queryResult: QueryResult = await bucket
-    .scope('tenant_agent_00')
-    .query('SELECT name FROM `users` WHERE $1 in interests', {
-      parameters: ['Swimming'],
+    .scope('inventory')
+    .query('SELECT name FROM `airline` WHERE country=$1 LIMIT 10', {
+      parameters: ['United States'],
     })
   console.log('Query Results:')
   queryResult.rows.forEach((row) => {

--- a/modules/hello-world/examples/start-using.js
+++ b/modules/hello-world/examples/start-using.js
@@ -1,4 +1,4 @@
-var couchbase = require('couchbase')
+const couchbase = require('couchbase')
 
 async function main() {
   // tag::connect[]
@@ -40,18 +40,11 @@ async function main() {
   const getResult = await collection.get('michael123')
   console.log('Get Result: ', getResult)
 
-  // Create a scoped primary index so we can query data
-  await cluster.queryIndexes().createPrimaryIndex('travel-sample', {
-    scopeName: 'tenant_agent_00',
-    collectionName: 'users',
-    ignoreIfExists: true,
-  })
-
   // Perform a N1QL Query
   const queryResult = await bucket
-    .scope('tenant_agent_00')
-    .query('SELECT name FROM `users` WHERE $1 in interests', {
-      parameters: ['Swimming'],
+    .scope('inventory')
+    .query('SELECT name FROM `airline` WHERE country=$1 LIMIT 10', {
+      parameters: ['United States'],
     })
   console.log('Query Results:')
   queryResult.rows.forEach((row) => {

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -52,7 +52,7 @@ As well as the Node.js SDK, and a running instance of Couchbase Server, you will
 using either the xref:7.1@server:manage:manage-settings/install-sample-buckets.adoc#install-sample-buckets-with-the-ui[Web interface]
 or the xref:7.1@server:manage:manage-settings/install-sample-buckets.adoc#install-sample-buckets-with-the-cli[command line].
 
-[source.try-it,nodejs]
+[source,nodejs]
 ----
 include::example$start-using.js[tags=**]
 ----
@@ -338,17 +338,7 @@ include::example$cloud.ts[tag=ts-get,indent=0]
 
 Couchbase N1QL queries are performed by invoking `Cluster.Query()`.
 
-To query our data, we will need to ensure that an _index_ is created for the `travel-sample`.`tenant_agent_00`.`users` keyspace path.
-If you are following along using the `travel-sample` bucket in Couchbase Capella, run the query below in the xref::cloud:clusters:query-service:query-workbench.adoc#accessing-the-query-workbench[Query Workbench].
-
-NOTE: You can ignore this step if you are not using the `travel-sample` bucket or already have an index created.
-
-[source,console]
-----
-CREATE PRIMARY INDEX ON `default`:`travel-sample`.`tenant_agent_00`.`users`
-----
-
-In the code below we will query Couchbase to retrieve users with a particular interest and print the results.
+In the code below we will query Couchbase to retrieve airlines by country and print the results.
 
 [{tabs}]
 ====

--- a/modules/test/test-hello-world.bats
+++ b/modules/test/test-hello-world.bats
@@ -17,8 +17,16 @@ Get Result:  GetResult {
 EOF
 
   assert_output --partial <<-EOF
-Query Results:
-{ name: 'Michael' }
+{ name: '40-Mile Air' }
+{ name: 'Texas Wings' }
+{ name: 'Atifly' }
+{ name: 'Locair' }
+{ name: 'SeaPort Airlines' }
+{ name: 'Alaska Central Express' }
+{ name: 'AirTran Airways' }
+{ name: 'U.S. Air' }
+{ name: 'PanAm World Airways' }
+{ name: 'Bemidji Airlines' }
 EOF
 }
 
@@ -39,8 +47,16 @@ Get Result:  GetResult {
 EOF
 
   assert_output --partial <<-EOF
-Query Results:
-{ name: 'Michael' }
+{ name: '40-Mile Air' }
+{ name: 'Texas Wings' }
+{ name: 'Atifly' }
+{ name: 'Locair' }
+{ name: 'SeaPort Airlines' }
+{ name: 'Alaska Central Express' }
+{ name: 'AirTran Airways' }
+{ name: 'U.S. Air' }
+{ name: 'PanAm World Airways' }
+{ name: 'Bemidji Airlines' }
 EOF
 }
 


### PR DESCRIPTION
Currently the `try-it-now` environment (Couchbase Playground) uses only
the default scopes and collections, and supplies at minimum just the
primary index.
Alot of our examples use named scopes and collections, and require
relevant indexes to be available in order for queries to be performed.

For now, I will remove `try-it-now` whilst this is looked into by the DA
team [here](https://issues.couchbase.com/browse/DEVADV-1980).

I've also removed the creation of a primary index in our Getting
Started to ensure we have a simple experience for users without adding
index creation/setup overhead.