### PR TITLE
Additions to root CA section

### DIFF
--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -152,11 +152,12 @@ Couchbase Server::
 --
 As of SDK 4.2, if you connect to a Couchbase Server cluster with a root certificate issued by a trusted CA (Certificate Authority), you no longer need to configure this in the `SecurityConfig` settings.
 
-The cluster's root certificate just needs to be issued by a CA whose certificate is in your system trust store.
-This includes publicly trusted CAs (e.g., GoDaddy, Verisign, etc...), plus any other CA certificates that you wish to add.
-The Node.js SDK uses https://github.com/couchbaselabs/couchbase-cxx-client[{cbpp}] internally to retrieve the platform root CA.
+The cluster's root certificate just needs to be issued by a CA whose certificate is in your OpenSSL trust store.
+This can include publicly trusted CAs (e.g., GoDaddy, Verisign, etc...), plus any other CA certificates that you wish to add.
+The Node.js SDK uses https://github.com/couchbaselabs/couchbase-cxx-client[{cbpp}] internally to retrieve the root CAs.
 
-IMPORTANT: {cbpp} loads your platform's root CA store using OpenSSL, therefore you should make sure that your system or platform is configured to support this.
+IMPORTANT: {cbpp} loads your root CA store using OpenSSL and depending on your Node installation, certificates might not be in the CA store by default.  You might need to configure the `SSL_CERT_DIR` or `SSL_CERT_FILE`
+environment variable to set the directory or root CA store file {cbpp} uses to retrieve root CAs.
 
 You can still provide a certificate explicitly if necessary:
 


### PR DESCRIPTION
Node.js comes bundled with it's own OpenSSL.  So, it will most likely be different than the OpenSSL version on the system.  I mention "depending on your Node installation" because it might be possible that some users build their version of Node and configure Node's OpenSSL when building.  In that case it seems plausible that the default store and/or store path will be configured as they would expect.