### PR TITLE
Added Ottoman 2.3.0 Release Notes

### DIFF
--- a/modules/project-docs/pages/ottoman-release-notes.adoc
+++ b/modules/project-docs/pages/ottoman-release-notes.adoc
@@ -12,16 +12,6 @@ These pages cover the 2._x_ versions of the Ottoman ODM.
 The Ottoman ODM will run on any https://github.com/nodejs/Release[supported LTS version of Node.js].
 
 
-
-== Node.js SDK 4.x Support
-
-Ottoman does *not* support Node.js SDK 4.x.
-We intend to fully support it in a future Ottoman release.
-
-In the meantime, if you are interested in checking out Ottoman, 
-please read the xref:3.2@nodejs-sdk:hello-world:start-using-ottoman.adoc[Ottoman for Node.js SDK 3.2] page.
-
-
 == Version 2.3.0 (19 December 2022)
 
 Version 2.3.0 is a minor release of the Ottoman ODM.

--- a/modules/project-docs/pages/ottoman-release-notes.adoc
+++ b/modules/project-docs/pages/ottoman-release-notes.adoc
@@ -22,6 +22,46 @@ In the meantime, if you are interested in checking out Ottoman,
 please read the xref:3.2@nodejs-sdk:hello-world:start-using-ottoman.adoc[Ottoman for Node.js SDK 3.2] page.
 
 
+== Version 2.3.0 (19 December 2022)
+
+Version 2.3.0 is a minor release of the Ottoman ODM.
+This release adds fixes and dependency upgrades, including a major version upgrade to the `couchbase` dependency.
+
+[source,console]
+----
+$ npm install ottoman@2.3.0
+----
+
+https://ottomanjs.com/#installation[Ottoman installation]
+
+=== Fixed Issues
+
+* Bumped `couchbase` dependency to `v4.2.0`.
+
+===  Important Configuration Change
+
+* This release includes a *major version bump* to the Couchbase dependency, and with it a specific change to handling SSL/TLS connections:
+    * If you were previously skipping certificate checking with the parameter `?ssl=no_verify` in your connection string, you'll need to update it to `?tls_verify=none`.
+    * More information can be found in [this article](https://developer.couchbase.com/tutorial-nodejs-tls-connection#tls-authentication-without-certificate-checking).
+
+
+== Version 2.2.2 (9 November 2022)
+
+Version 2.2.2 is a patch release of the Ottoman ODM.
+This release adds minor fixes and dependency upgrades, including a patch version upgrade to the `couchbase` dependency.
+
+[source,console]
+----
+$ npm install ottoman@2.2.2
+----
+
+https://ottomanjs.com/#installation[Ottoman installation]
+
+=== Fixed Issues
+
+* Bumped `couchbase` dependency to `v3.2.6`.
+
+
 == Version 2.2.1 (22 June 2022)
 
 Version 2.2.1 is a patch release of the Ottoman ODM.


### PR DESCRIPTION
- Adds release notes for Ottoman 2.3.0
- Removes note about Ottoman not supporting Node.js SDK 4.x, as this release adds support for 4.x