### PR TITLE
[AV-82442] Update Nodejs release 4.1 docs for Free Tier

### DIFF
--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -59,7 +59,7 @@ include::example$start-using.js[tags=**]
 --
 ====
 
-The Couchbase Capella free trial version comes with the Travel Sample Bucket, and its Query indexes, loaded and ready.
+The Couchbase Capella free tier version comes with the Travel Sample Bucket, and its Query indexes, loaded and ready.
 
 == Quick Installation
 


### PR DESCRIPTION
Removed mentions of trial in the Nodejs SDK docs. Only locations found were the start-using-sdk.adoc page.