### PR TITLE
JSCBC-1357: Fix how client handles KV expiry

### DIFF
--- a/modules/devguide/examples/nodejs/kv-operations.js
+++ b/modules/devguide/examples/nodejs/kv-operations.js
@@ -168,6 +168,45 @@ async function insertwithoptionsHandler(request, h) {
     }
 }
 
+async function insertRelativeHandler(request, h) {
+    const key = request.query.k ? request.query.k : docKey;
+    [document.type, document.id] = key.split("_");
+    try {
+        // #tag::insert-relative[]
+        const result = await collection.insert(key, document,
+            { expiry: 100 } // 100 seconds
+        );
+        // #end::insert-relative[]
+        cas = result.cas; // JSCBC-669?
+        return h.response(result);
+    } catch (e) {
+        console.log(e);
+        return h.response(e.toString() + " - try 'remove' first if document exists");
+    }
+}
+
+async function insertAbsoluteHandler(request, h) {
+    const key = request.query.k ? request.query.k : docKey;
+    [document.type, document.id] = key.split("_");
+    try {
+        // #tag::insert-absolute[]
+        const expiryAsAbsoluteDate = (seconds) => {
+            const now = new Date()
+            return new Date(now.getTime() + seconds * 1000)
+        }
+        const expiryDate = expiryAsAbsoluteDate(60 * 24 * 60 * 60);  // 60 days
+        const result = await collection.insert(key, document,
+            { expiry: expiryDate }
+        );
+        // #end::insert-absolute[]
+        cas = result.cas; // JSCBC-669?
+        return h.response(result);
+    } catch (e) {
+        console.log(e);
+        return h.response(e.toString() + " - try 'remove' first if document exists");
+    }
+}
+
 async function replaceHandler(request, h) {
     const key = request.query.k ? request.query.k : docKey;
     try {
@@ -272,6 +311,37 @@ async function touchwithoptionsHandler(request, h) {
             { timeout: 5000 } // 5 seconds
         );
         // #end::touchwithoptions[]
+        return h.response(result);
+    } catch (e) {
+        console.log(e);
+        return h.response(e.toString());
+    }
+}
+
+async function touchRelativeHandler(request, h) {
+    const key = request.query.k ? request.query.k : docKey;
+    try {
+        // #tag::touch-relative[]
+        const result = await collection.touch(key, 100); // 100 seconds
+        // #end::touch-relative[]
+        return h.response(result);
+    } catch (e) {
+        console.log(e);
+        return h.response(e.toString());
+    }
+}
+
+async function touchAbsoluteHandler(request, h) {
+    const key = request.query.k ? request.query.k : docKey;
+    try {
+        // #tag::touch-absolute[]
+        const expiryAsAbsoluteDate = (seconds) => {
+            const now = new Date()
+            return new Date(now.getTime() + seconds * 1000)
+        }
+        const expiryDate = expiryAsAbsoluteDate(60 * 24 * 60 * 60);  // 60 days
+        const result = await collection.touch(key, expiryDate);
+        // #end::touch-absolute[]
         return h.response(result);
     } catch (e) {
         console.log(e);
@@ -734,6 +804,22 @@ server.route({
 
 server.route({
     method: "GET",
+    path: "/insertrelative",
+    handler: async (request, h) => {
+        return await insertRelativeHandler(request, h);
+    }
+});
+
+server.route({
+    method: "GET",
+    path: "/insertabsolute",
+    handler: async (request, h) => {
+        return await insertAbsoluteHandler(request, h);
+    }
+});
+
+server.route({
+    method: "GET",
     path: "/replace",
     handler: async (request, h) => {
         return await replaceHandler(request, h);
@@ -777,6 +863,22 @@ server.route({
     path: "/touchwithoptions",
     handler: async (request, h) => {
         return await touchwithoptionsHandler(request, h);
+    }
+});
+
+server.route({
+    method: "GET",
+    path: "/touchrelative",
+    handler: async (request, h) => {
+        return await touchRelativeHandler(request, h);
+    }
+});
+
+server.route({
+    method: "GET",
+    path: "/touchabsolute",
+    handler: async (request, h) => {
+        return await touchAbsoluteHandler(request, h);
     }
 });
 

--- a/modules/howtos/pages/kv-operations.adoc
+++ b/modules/howtos/pages/kv-operations.adoc
@@ -172,12 +172,38 @@ include::devguide:example$nodejs/kv-operations.js[tag=remove,indent=0]
 == Expiration / TTL
 
 By default, Couchbase documents do not expire, but transient or temporary data may be needed for user sessions, caches, or other temporary documents.
-Using `touch()`, you can set expiration values on documents to handle transient data:
+Using `touch()`, or setting the `expiry` option for certain mutation operations, you can set expiration values on documents to handle transient data.
 
+You can set an expiry value as relative seconds from now by passing in a number. A relative expiry should only be used when the expiry value is less than 50 years.  For expiry values greater than 50 years, use an absolute expiry value (see below).
+
+IMPORTANT: Using a Unix timestamp (e.g. `Math.floor(Date.now() / 1000) + 100 // 100 seconds`) as an absolute value is not supported.  As of v4.6.0 absolute values should be specified as a `Date`.  Prior to v4.6.0 expiry should only be specifed as a relative number of seconds.
+
+Using `touch()`:
 [source,javascript]
 ----
-include::devguide:example$nodejs/kv-operations.js[tag=touch,indent=0]
+include::devguide:example$nodejs/kv-operations.js[tag=touch-relative,indent=0]
 ----
+
+Using `insert()`:
+[source,javascript]
+----
+include::devguide:example$nodejs/kv-operations.js[tag=insert-relative,indent=0]
+----
+
+From version 4.6.0 on, expiry can be expressed as an absolute value by passing in a `Date`.
+
+Using `touch()`:
+[source,javascript]
+----
+include::devguide:example$nodejs/kv-operations.js[tag=touch-absolute,indent=0]
+----
+
+Using `insert()`:
+[source,javascript]
+----
+include::devguide:example$nodejs/kv-operations.js[tag=insert-absolute,indent=0]
+----
+
 
 A network timeout can be set with the options, in the same fashion as earlier examples on this page:
 
@@ -185,8 +211,6 @@ A network timeout can be set with the options, in the same fashion as earlier ex
 ----
 include::devguide:example$nodejs/kv-operations.js[tag=touchwithoptions,indent=0]
 ----
-
-include::{version-common}@sdk:shared:partial$documents.adoc[tag=exp-note]
 
 
 == Atomic Counters

--- a/modules/howtos/pages/kv-operations.adoc
+++ b/modules/howtos/pages/kv-operations.adoc
@@ -174,9 +174,12 @@ include::devguide:example$nodejs/kv-operations.js[tag=remove,indent=0]
 By default, Couchbase documents do not expire, but transient or temporary data may be needed for user sessions, caches, or other temporary documents.
 Using `touch()`, or setting the `expiry` option for certain mutation operations, you can set expiration values on documents to handle transient data.
 
-You can set an expiry value as relative seconds from now by passing in a number. A relative expiry should only be used when the expiry value is less than 50 years.  For expiry values greater than 50 years, use an absolute expiry value (see below).
+You can set an expiry value as relative seconds from now by passing in a number.
+A relative expiry should only be used when the expiry value is less than 50 years.
+For expiry values greater than 50 years, use an absolute expiry value (see below).
 
-IMPORTANT: Using a Unix timestamp (e.g. `Math.floor(Date.now() / 1000) + 100 // 100 seconds`) as an absolute value is not supported.  As of v4.6.0 absolute values should be specified as a `Date`.  Prior to v4.6.0 expiry should only be specifed as a relative number of seconds.
+IMPORTANT: Using a Unix timestamp (e.g. `Math.floor(Date.now() / 1000) + 100 // 100 seconds`) as an absolute value is not supported. 
+As of v4.6.0 absolute values should be specified as a `Date`.  Prior to v4.6.0 expiry should only be specifed as a relative number of seconds.
 
 Using `touch()`:
 [source,javascript]


### PR DESCRIPTION
Changes
=======
* Update expiry examples to show relative and absolute expiry values.
* Add `insert` to expiry examples.
* Include note that Unix timestamps are not supported.  The note also indicates what to do prior to v4.6.0 (where JSCBC-1357 is applied). This should be okay as v4.3.1 included JSCBC-1245 which introduced logic to handle the relative expiry appropriately and as of this change 4.3 is the oldest supported version of the Node.js SDK.