### PR TITLE
[DOC-13566]: Correct typo, refine instructions for Capella cluster connections

### DIFF
--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -33,6 +33,8 @@ const clusterConnStr = 'couchbases://cb.<your-endpoint>.cloud.couchbase.com'
 `couchbases://` -- note the final `s` -- is needed for SSL.
 The Capella client certificate is included with the SDK.
 
+For a self-managed cluster:
+
 .Connecting to a self-managed Couchbase cluster
 [source,javascript]
 ----

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -21,9 +21,10 @@ include::example$auth.js[tag=rbac-auth,indent=0]
 ----
 
 
-For a , substitute the `localhost` line with:
+If you're connecting to a Capella cluster,
+substitute the `localhost` line with the cluster's endpoint address.
 
-.Connceting to a Capella cluster
+.Connecting to a Capella cluster
 [source,javascript]
 ----
 const clusterConnStr = 'couchbases://cb.<your-endpoint>.cloud.couchbase.com'

--- a/preview/DOC-13566-Feedback-on-Managing-Connections--Couchbase-Docs.yml
+++ b/preview/DOC-13566-Feedback-on-Managing-Connections--Couchbase-Docs.yml
@@ -1,0 +1,3 @@
+sources:
+  docs-sdk-nodejs:
+    branches: [DOC-13566-Feedback-on-Managing-Connections--Couchbase-Docs]


### PR DESCRIPTION
Updated documentation to fix a typo and enhance clarity on instructions for connecting to Capella clusters. Also added a preview of YAML configuration for user reference.

----

Preview URL:
https://preview.docs-test.couchbase.com/docs-sdk-nodejs-DOC-13566-Feedback-on-Managing-Connections--Couchbase-Docs

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.
