### PR TITLE
Including the IDE Plugins section to the SDK Node JS doc in the new 4…

### DIFF
--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -139,11 +139,12 @@ If you intend to use `TypeScript` instead of `JavaScript`, then also do the foll
 $ npm install -g typescript ts-node
 ----
 
-// === IDE Plugins
-//
-// To make development easier, Couchbase plugins are available for VSCode and the IntelliJ family of IDEs and editors.
-// For links and more information on these and other integrations across the {name_platform} ecosystem,
-// check out the xref:project-docs:third-party-integrations.adoc[] page.
+=== IDE Plugins
+
+To make development easier, Couchbase plugins are available for VSCode and the IntelliJ family of IDEs and editors.
+For links and more information on these and other integrations across the {name_platform} ecosystem,
+check out the xref:project-docs:third-party-integrations.adoc[] page.
+
 
 === Grab the Code
 


### PR DESCRIPTION
[DOC-13726](https://jira.issues.couchbase.com/browse/DOC-13726)

Included the missing IDE Plugins section.

[Preview credentials](https://preview.docs-test.couchbase.com/docs-sdk-nodejs-DOC-13726-Add-the-missing-IDE-info-in-temp-4.6/nodejs-sdk/current/hello-world/start-using-sdk.html)

[DOC-13726]: https://couchbasecloud.atlassian.net/browse/DOC-13726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ